### PR TITLE
Wann90 changes

### DIFF
--- a/electronicparsers/wannier90/parser.py
+++ b/electronicparsers/wannier90/parser.py
@@ -60,12 +60,6 @@ class WOutParser(TextParser):
             Quantity(
                 'positions', rf'\|\s*([\-\d\.]+)\s*([\-\d\.]+)\s*([\-\d\.]+)', repeats=True)]
 
-        orbitals_quantities = [
-            Quantity(
-                'names', r'\|\s*([A-Za-z\.\s\-\/]+)\|', repeats=False),
-            Quantity(
-                'parameters', r'\|\s*([\d\.\s\-\/]*)\|', repeats=True)]
-
         self._quantities = [
             # Program quantities
             Quantity(
@@ -84,9 +78,6 @@ class WOutParser(TextParser):
             Quantity(
                 'k_mesh', rf'\s*(K-POINT GRID[\s\S]+?)(?:-\s*MAIN)', repeats=False,
                 sub_parser=TextParser(quantities=kmesh_quantities)),
-            Quantity(
-                'orbitals', rf'\s*(PROJECTIONS[\s\S]+?)(?:\s*K-POINT GRID)', repeats=False,
-                sub_parser=TextParser(quantities=orbitals_quantities)),
             Quantity(
                 'Nwannier', r'\|\s*Number of Wannier Functions\s*\:\s*(\d+)',
                 repeats=False),
@@ -148,45 +139,6 @@ class Wannier90Parser:
             'Nwannier': 'n_projected_orbitals',
             'Nband': 'n_bands',
             'conv_tol': 'convergence_tolerance_max_localization'
-        }
-
-        self._angular_momentum_table = {
-            's': [0, 1],
-            'pz': [1, 1],
-            'px': [1, 2],
-            'py': [1, 3],
-            'dz2': [2, 1],
-            'dxz': [2, 2],
-            'dyz': [2, 3],
-            'dx2-y2': [2, 4],
-            'dxy': [2, 5],
-            'fz3': [3, 1],
-            'fxz2': [3, 2],
-            'fyz2': [3, 3],
-            'fz(x2-y2)': [3, 4],
-            'fxyz': [3, 5],
-            'fx(x2-3y2)': [3, 6],
-            'fy(3x2-y2)': [3, 7],
-            'sp-1': [-1, 1],
-            'sp-2': [-1, 2],
-            'sp2-1': [-2, 1],
-            'sp2-2': [-2, 2],
-            'sp2-3': [-2, 3],
-            'sp3-1': [-3, 1],
-            'sp3-2': [-3, 2],
-            'sp3-3': [-3, 3],
-            'sp3-4': [-3, 4],
-            'sp3d-1': [-4, 1],
-            'sp3d-2': [-4, 2],
-            'sp3d-3': [-4, 3],
-            'sp3d-4': [-4, 4],
-            'sp3d-5': [-4, 5],
-            'sp3d2-1': [-5, 1],
-            'sp3d2-2': [-5, 2],
-            'sp3d2-3': [-5, 3],
-            'sp3d2-4': [-5, 4],
-            'sp3d2-5': [-5, 5],
-            'sp3d2-6': [-5, 6]
         }
 
     def parse_system(self, archive, wout_parser):

--- a/electronicparsers/wannier90/parser.py
+++ b/electronicparsers/wannier90/parser.py
@@ -238,7 +238,7 @@ class Wannier90Parser:
         sec_hopping_matrix.n_orbitals = self.archive.run[-1].method[-1].projection.n_projected_orbitals
         sec_hopping_matrix.n_wigner_seitz_points = self.hr_parser.get('degeneracy_factors')[1]
         sec_hopping_matrix.degeneracy_factors = self.hr_parser.get('degeneracy_factors')[2:]
-        full_hoppings = np.array(self.hr_parser.get('hoppings'))
+        full_hoppings = self.hr_parser.get('hoppings')
         sec_hopping_matrix.value = np.reshape(
             full_hoppings, (sec_hopping_matrix.n_wigner_seitz_points, sec_hopping_matrix.n_orbitals * sec_hopping_matrix.n_orbitals, 7))
 

--- a/electronicparsers/wannier90/parser.py
+++ b/electronicparsers/wannier90/parser.py
@@ -140,21 +140,21 @@ class Wannier90Parser:
             'conv_tol': 'convergence_tolerance_max_localization'
         }
 
-    def parse_system(self):
-        sec_run = self.archive.run[-1]
+    def parse_system(self, archive, wout_parser):
+        sec_run = archive.run[-1]
         sec_system = sec_run.m_create(System)
 
         sec_atoms = sec_system.m_create(Atoms)
-        if self.wout_parser.get('lattice_vectors') is not None:
-            sec_atoms.lattice_vectors = np.vstack(self.wout_parser.get('lattice_vectors')) * ureg.angstrom
-        if self.wout_parser.get('reciprocal_lattice_vectors') is not None:
-            sec_atoms.lattice_vectors_reciprocal = np.vstack(self.wout_parser.get('reciprocal_lattice_vectors')) / ureg.angstrom
+        if wout_parser.get('lattice_vectors') is not None:
+            sec_atoms.lattice_vectors = np.vstack(wout_parser.get('lattice_vectors')) * ureg.angstrom
+        if wout_parser.get('reciprocal_lattice_vectors') is not None:
+            sec_atoms.lattice_vectors_reciprocal = np.vstack(wout_parser.get('reciprocal_lattice_vectors')) / ureg.angstrom
 
-        pbc = [np.vstack(self.wout_parser.get('lattice_vectors')) is not None] * 3
+        pbc = [np.vstack(wout_parser.get('lattice_vectors')) is not None] * 3
         sec_atoms.periodic = pbc
 
-        sec_atoms.labels = self.wout_parser.get('structure').get('labels')
-        sec_atoms.positions = self.wout_parser.get('structure').get('positions') * ureg.angstrom
+        sec_atoms.labels = wout_parser.get('structure').get('labels')
+        sec_atoms.positions = wout_parser.get('structure').get('positions') * ureg.angstrom
 
     def parse_method(self):
         sec_run = self.archive.run[-1]
@@ -344,7 +344,7 @@ class Wannier90Parser:
             name='Wannier90', version=self.wout_parser.get('version', ''))
         # TODO TimeRun section
 
-        self.parse_system()
+        self.parse_system(self.archive, self.wout_parser)
 
         self.parse_method()
 

--- a/electronicparsers/wannier90/parser.py
+++ b/electronicparsers/wannier90/parser.py
@@ -29,6 +29,7 @@ from nomad.datamodel.metainfo.simulation.calculation import (
 )
 from nomad.datamodel.metainfo.simulation.method import Method, KMesh, Projection
 from nomad.datamodel.metainfo.simulation.system import System, Atoms
+from nomad.datamodel.metainfo.workflow import Workflow
 
 re_n = r'[\n\r]'
 
@@ -294,7 +295,7 @@ class Wannier90Parser:
         if not band_files:
             return
         if len(band_files) > 1:
-            self.logger.warn('Multiple bandstructure data files found.')
+            self.logger.warning('Multiple bandstructure data files found.')
         # Parsing only first *_band.dat file
         self.band_dat_parser.mainfile = os.path.join(self.maindir, band_files[0])
 
@@ -339,7 +340,7 @@ class Wannier90Parser:
         if not dos_files:
             return
         if len(dos_files) > 1:
-            self.logger.warn('Multiple dos data files found.')
+            self.logger.warning('Multiple dos data files found.')
         # Parsing only first *_band.dat file
         self.dos_dat_parser.mainfile = os.path.join(self.maindir, dos_files[0])
 
@@ -385,6 +386,8 @@ class Wannier90Parser:
         if not wout_files:
             self.logger.error('Error finding the woutput file.')
 
+        self.wout_parser.mainfile = os.path.join(self.maindir, wout_files[0])
+
         # Program section
         sec_run.program = Program(
             name='Wannier90', version=self.wout_parser.get('version', ''))
@@ -395,3 +398,6 @@ class Wannier90Parser:
         self.parse_method()
 
         self.parse_scc()
+
+        sec_workflow = self.archive.m_create(Workflow)
+        sec_workflow.type = 'single_point'


### PR DESCRIPTION
I want to improve a bit the parser to make the method `parse_system` callable.

This is because many advanced many-body methods (like DMFT) don't store anywhere the system geometry, except for from the Wannier90 output files themselves. This way I can call `Wannier90Parser:parse_system` in more advanced parser.