### PR TITLE
Mod in Wannier90 method.projection

### DIFF
--- a/electronicparsers/wannier90/parser.py
+++ b/electronicparsers/wannier90/parser.py
@@ -147,11 +147,11 @@ class Wannier90Parser:
 
         sec_atoms = sec_system.m_create(Atoms)
         if wout_parser.get('lattice_vectors') is not None:
-            sec_atoms.lattice_vectors = np.vstack(wout_parser.get('lattice_vectors')) * ureg.angstrom
+            sec_atoms.lattice_vectors = np.vstack(wout_parser.get('lattice_vectors')[-3:]) * ureg.angstrom
         if wout_parser.get('reciprocal_lattice_vectors') is not None:
-            sec_atoms.lattice_vectors_reciprocal = np.vstack(wout_parser.get('reciprocal_lattice_vectors')) / ureg.angstrom
+            sec_atoms.lattice_vectors_reciprocal = np.vstack(wout_parser.get('reciprocal_lattice_vectors')[-3:]) / ureg.angstrom
 
-        pbc = [np.vstack(wout_parser.get('lattice_vectors')) is not None] * 3
+        pbc = [np.vstack(wout_parser.get('lattice_vectors')[-3:]) is not None] * 3
         sec_atoms.periodic = pbc
 
         sec_atoms.labels = wout_parser.get('structure').get('labels')

--- a/tests/test_wannier90parser.py
+++ b/tests/test_wannier90parser.py
@@ -47,11 +47,11 @@ def test_lco(parser):
     assert sec_system[0].atoms.lattice_vectors[0][0].magnitude == approx(-1.909145e-10)
     assert sec_system[0].atoms.periodic == [True, True, True]
 
-    sec_projection = archive.run[0].method[0].projection
-    assert sec_projection.n_projected_orbitals == 1
-    assert sec_projection.n_bands == 5
-    assert sec_projection.is_maximally_localized is True
-    assert sec_projection.k_mesh.n_points == 343
+    sec_wannier = archive.run[0].method[0].projection.wannier
+    assert sec_wannier.n_projected_orbitals == 1
+    assert sec_wannier.n_bands == 5
+    assert sec_wannier.is_maximally_localized is True
+    assert sec_wannier.k_mesh.n_points == 343
 
     # Band tests
     sec_scc = archive.run[0].calculation
@@ -73,7 +73,7 @@ def test_lco(parser):
     sec_hoppings = sec_scc[0].hopping_matrix[0]
     assert sec_hoppings.n_wigner_seitz_points == 397
     assert sec_hoppings.n_wigner_seitz_points == len(sec_hoppings.degeneracy_factors)
-    assert sec_hoppings.n_orbitals == sec_projection.n_projected_orbitals
+    assert sec_hoppings.n_orbitals == sec_wannier.n_projected_orbitals
     assert sec_hoppings.value.shape[0] == sec_hoppings.n_wigner_seitz_points
     assert sec_hoppings.value.shape[1] == sec_hoppings.n_orbitals
     assert sec_hoppings.value.shape[2] == 7


### PR DESCRIPTION
I restructured the Method.Projection section to contain 2 subsections: Wannier, which is the one defined currently in nomad, and SlaterKoster, which will be defined soon.

This is because the projection can be done with two distinct methodologies (the above ones). Later I will push a parser for a code which deals with the SlaterKoster-like projection.