### PR TITLE
HubbardModel to HubbardKanamoriModel renaming

### DIFF
--- a/electronicparsers/fhiaims/metainfo/fhi_aims.py
+++ b/electronicparsers/fhiaims/metainfo/fhi_aims.py
@@ -1441,9 +1441,16 @@ class AtomParameters(simulation.method.AtomParameters):
         repeats=True)
 
 
-class HubbardModel(simulation.method.HubbardModel):
+class HubbardKanamoriModel(simulation.method.HubbardKanamoriModel):
 
     m_def = Section(validate=False, extends_base_section=True)
+
+    x_fhi_aims_projection_type = Quantity(
+        type=str,
+        shape=[],
+        description='''
+        Type of orbitals used for projection in order to calculate occupation numbers.
+        ''')
 
     x_fhi_aims_petukhov_mixing_factor = Quantity(
         type=np.dtype(np.float64),

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -1587,7 +1587,7 @@ class FHIAimsParser:
                     sec_atom_species.x_fhi_aims_controlInOut_species_cut_pot_scale = val[0][2]
                 elif "request for '+U'" in key:
                     sec_hubbard = sec_atom_type.m_create(HubbardKanamoriModel)
-                    sec_hubbard.orbital = f'{val[0][1]}'
+                    sec_hubbard.orbital = f'{val[0][0]}{val[0][1]}'
                     sec_hubbard.u_effective = val[0][-2] * ureg.eV
                     sec_hubbard.double_counting_correction = 'Dudarev'
                     sec_hubbard.x_fhi_aims_projection_type = 'Mulliken (dual)'

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -1588,7 +1588,7 @@ class FHIAimsParser:
                 elif "request for '+U'" in key:
                     sec_hubbard = sec_atom_type.m_create(HubbardKanamoriModel)
                     sec_hubbard.orbital = f'{val[0][1]}'
-                    sec_hubbard.u_effective = val[0][-2]
+                    sec_hubbard.u_effective = val[0][-2] * ureg.eV
                     sec_hubbard.double_counting_correction = 'Dudarev'
                     sec_hubbard.x_fhi_aims_projection_type = 'Mulliken (dual)'
                     sec_hubbard.x_fhi_aims_petukhov_mixing_factor = self.out_parser.get('petukhov')

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -26,7 +26,7 @@ from nomad.parsing.file_parser import TextParser, Quantity, DataTextParser
 
 from nomad.datamodel.metainfo.simulation.run import Run, Program, TimeRun
 from nomad.datamodel.metainfo.simulation.method import (
-    Electronic, Method, XCFunctional, Functional, HubbardModel, AtomParameters, DFT,
+    Electronic, Method, XCFunctional, Functional, HubbardKanamoriModel, AtomParameters, DFT,
     BasisSet, GW as GWMethod, KMesh
 )
 from nomad.datamodel.metainfo.simulation.system import (
@@ -1586,11 +1586,11 @@ class FHIAimsParser:
                     sec_atom_species.x_fhi_aims_controlInOut_species_cut_pot_width = val[0][1] * ureg.angstrom
                     sec_atom_species.x_fhi_aims_controlInOut_species_cut_pot_scale = val[0][2]
                 elif "request for '+U'" in key:
-                    sec_hubbard = sec_atom_type.m_create(HubbardModel)
-                    sec_hubbard.orbital = f'{val[0][0]}{val[0][1]}'
-                    sec_hubbard.u_effective = val[0][-2] * ureg.eV
-                    sec_hubbard.method = 'Dudarev'
-                    sec_hubbard.projection_type = 'Mulliken (dual)'
+                    sec_hubbard = sec_atom_type.m_create(HubbardKanamoriModel)
+                    sec_hubbard.orbital = f'{val[0][1]}'
+                    sec_hubbard.u_effective = val[0][-2]
+                    sec_hubbard.double_counting_correction = 'Dudarev'
+                    sec_hubbard.x_fhi_aims_projection_type = 'Mulliken (dual)'
                     sec_hubbard.x_fhi_aims_petukhov_mixing_factor = self.out_parser.get('petukhov')
                 elif 'free-atom' in key or 'free-ion' in key:
                     for i in range(len(val)):

--- a/electronicparsers/vasp/metainfo/vasp.py
+++ b/electronicparsers/vasp/metainfo/vasp.py
@@ -134,3 +134,15 @@ class System(simulation.system.System):
         description='''
         Boolean array to eiter allow or forbid coordinate modifications during relaxation
         ''')
+
+
+class HubbardKanamoriModel(simulation.method.HubbardKanamoriModel):
+
+    m_def = Section(validate=False, extends_base_section=True)
+
+    x_vasp_projection_type = Quantity(
+        type=str,
+        shape=[],
+        description='''
+        Type of orbitals used for projection in order to calculate occupation numbers.
+        ''')

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -43,7 +43,7 @@ from nomad.parsing.file_parser import FileParser
 from nomad.parsing.file_parser.text_parser import TextParser, Quantity
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
-    Method, BasisSet, BasisSetCellDependent, DFT, HubbardModel, AtomParameters, XCFunctional,
+    Method, BasisSet, BasisSetCellDependent, DFT, HubbardKanamoriModel, AtomParameters, XCFunctional,
     Functional, Electronic, Scf
 )
 from nomad.datamodel.metainfo.simulation.system import (
@@ -1118,7 +1118,7 @@ class VASPParser:
     def __init__(self):
         self._vasprun_parser = RunContentParser()
         self._outcar_parser = OutcarContentParser()
-        self.hubbard_method_types = {1: 'Liechtenstein', 2: 'Dudarev', 4: 'Liechtenstein without exchange splitting'}
+        self.hubbard_dc_corrections = {1: 'Liechtenstein', 2: 'Dudarev', 4: 'Liechtenstein without exchange splitting'}
         self.hubbard_orbital_types = {-1: None, 0: 's', 1: 'p', 2: 'd', 3: 'f'}
 
     def init_parser(self, filepath, logger):
@@ -1209,12 +1209,12 @@ class VASPParser:
             if hubbard_present:
                 orbital = self.hubbard_orbital_types[int(parsed_file.get('LDAUL')[i])]
                 if orbital:
-                    sec_hubb = sec_method_atom_kind.m_create(HubbardModel)
+                    sec_hubb = sec_method_atom_kind.m_create(HubbardKanamoriModel)
                     sec_hubb.orbital = orbital
-                    sec_hubb.u = float(parsed_file.get('LDAUU')[i]) * ureg.eV
-                    sec_hubb.j = float(parsed_file.get('LDAUJ')[i]) * ureg.eV
-                    sec_hubb.method = self.hubbard_method_types[parsed_file.get('LDAUTYPE')]
-                    sec_hubb.projection_type = 'on-site'
+                    sec_hubb.u = float(parsed_file.get('LDAUU')[i])
+                    sec_hubb.j = float(parsed_file.get('LDAUJ')[i])
+                    sec_hubb.double_counting_correction = self.hubbard_dc_corrections[parsed_file.get('LDAUTYPE')]
+                    sec_hubb.x_vasp_projection_type = 'on-site'
             atom_counts[element[i]] += 1
         sec_method.x_vasp_atom_kind_refs = sec_method.atom_parameters
 

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -1211,8 +1211,8 @@ class VASPParser:
                 if orbital:
                     sec_hubb = sec_method_atom_kind.m_create(HubbardKanamoriModel)
                     sec_hubb.orbital = orbital
-                    sec_hubb.u = float(parsed_file.get('LDAUU')[i])
-                    sec_hubb.j = float(parsed_file.get('LDAUJ')[i])
+                    sec_hubb.u = float(parsed_file.get('LDAUU')[i]) * ureg.eV
+                    sec_hubb.j = float(parsed_file.get('LDAUJ')[i]) * ureg.eV
                     sec_hubb.double_counting_correction = self.hubbard_dc_corrections[parsed_file.get('LDAUTYPE')]
                     sec_hubb.x_vasp_projection_type = 'on-site'
             atom_counts[element[i]] += 1

--- a/tests/test_fhiaimsparser.py
+++ b/tests/test_fhiaimsparser.py
@@ -248,8 +248,8 @@ def test_dftu(parser):
     archive = EntryArchive()
     parser.parse('tests/data/fhiaims/CeO2_dftu/aims_CC.out', archive, None)
 
-    sec_hubb = archive.run[-1].method[0].atom_parameters[0].hubbard_model
-    assert sec_hubb.orbital == 'f'
+    sec_hubb = archive.run[-1].method[0].atom_parameters[0].hubbard_kanamori_model
+    assert sec_hubb.orbital == '4f'
     assert approx(sec_hubb.u_effective.to('eV').magnitude) == 4.5
     assert sec_hubb.double_counting_correction == 'Dudarev'
 

--- a/tests/test_fhiaimsparser.py
+++ b/tests/test_fhiaimsparser.py
@@ -249,9 +249,9 @@ def test_dftu(parser):
     parser.parse('tests/data/fhiaims/CeO2_dftu/aims_CC.out', archive, None)
 
     sec_hubb = archive.run[-1].method[0].atom_parameters[0].hubbard_model
-    assert sec_hubb.orbital == '4f'
-    assert approx(sec_hubb.u_effective.to('eV').magnitude) == 4.5
-    assert sec_hubb.method == 'Dudarev'
+    assert sec_hubb.orbital == 'f'
+    assert approx(sec_hubb.u_effective.magnitude) == 4.5
+    assert sec_hubb.double_counting_correction == 'Dudarev'
 
 
 def test_gw(parser):

--- a/tests/test_fhiaimsparser.py
+++ b/tests/test_fhiaimsparser.py
@@ -250,7 +250,7 @@ def test_dftu(parser):
 
     sec_hubb = archive.run[-1].method[0].atom_parameters[0].hubbard_model
     assert sec_hubb.orbital == 'f'
-    assert approx(sec_hubb.u_effective.magnitude) == 4.5
+    assert approx(sec_hubb.u_effective.to('eV').magnitude) == 4.5
     assert sec_hubb.double_counting_correction == 'Dudarev'
 
 

--- a/tests/test_vaspparser.py
+++ b/tests/test_vaspparser.py
@@ -268,13 +268,13 @@ def test_dftu_static(parser):
         slice = 0
         for param in params:
             if param.hubbard_model:
-                assert param.hubbard_model.method == 'Dudarev'
+                assert param.hubbard_model.double_counting_correction == 'Dudarev'
                 assert param.hubbard_model.orbital == references['orbital'][slice]
-                assert approx(param.hubbard_model.u.to(ureg.eV).magnitude) == references['u'][slice]
-                assert approx(param.hubbard_model.j.to(ureg.eV).magnitude) == references['j'][slice]
+                assert approx(param.hubbard_model.u.magnitude) == references['u'][slice]
+                assert approx(param.hubbard_model.j.magnitude) == references['j'][slice]
                 slice += 1
 
     # check the OUTCAR value when no INCAR is present
     parser.parse('tests/data/vasp/Mg4V2Bi2O12_dftu_no_incar/OUTCAR', archive, None)
     params = archive.run[-1].method[-1].atom_parameters
-    assert approx(params[1].hubbard_model.u.to(ureg.eV).magnitude) == 3.2
+    assert approx(params[1].hubbard_model.u.magnitude) == 3.2

--- a/tests/test_vaspparser.py
+++ b/tests/test_vaspparser.py
@@ -267,14 +267,14 @@ def test_dftu_static(parser):
         references = {'orbital': ('d', 'd'), 'u': (3.25, 2.), 'j': (0., 1.)}
         slice = 0
         for param in params:
-            if param.hubbard_model:
-                assert param.hubbard_model.double_counting_correction == 'Dudarev'
-                assert param.hubbard_model.orbital == references['orbital'][slice]
-                assert approx(param.hubbard_model.u.to('eV').magnitude) == references['u'][slice]
-                assert approx(param.hubbard_model.j.to('eV').magnitude) == references['j'][slice]
+            if param.hubbard_kanamori_model:
+                assert param.hubbard_kanamori_model.double_counting_correction == 'Dudarev'
+                assert param.hubbard_kanamori_model.orbital == references['orbital'][slice]
+                assert approx(param.hubbard_kanamori_model.u.to('eV').magnitude) == references['u'][slice]
+                assert approx(param.hubbard_kanamori_model.j.to('eV').magnitude) == references['j'][slice]
                 slice += 1
 
     # check the OUTCAR value when no INCAR is present
     parser.parse('tests/data/vasp/Mg4V2Bi2O12_dftu_no_incar/OUTCAR', archive, None)
     params = archive.run[-1].method[-1].atom_parameters
-    assert approx(params[1].hubbard_model.u.to('eV').magnitude) == 3.2
+    assert approx(params[1].hubbard_kanamori_model.u.to('eV').magnitude) == 3.2

--- a/tests/test_vaspparser.py
+++ b/tests/test_vaspparser.py
@@ -270,11 +270,11 @@ def test_dftu_static(parser):
             if param.hubbard_model:
                 assert param.hubbard_model.double_counting_correction == 'Dudarev'
                 assert param.hubbard_model.orbital == references['orbital'][slice]
-                assert approx(param.hubbard_model.u.magnitude) == references['u'][slice]
-                assert approx(param.hubbard_model.j.magnitude) == references['j'][slice]
+                assert approx(param.hubbard_model.u.to('eV').magnitude) == references['u'][slice]
+                assert approx(param.hubbard_model.j.to('eV').magnitude) == references['j'][slice]
                 slice += 1
 
     # check the OUTCAR value when no INCAR is present
     parser.parse('tests/data/vasp/Mg4V2Bi2O12_dftu_no_incar/OUTCAR', archive, None)
     params = archive.run[-1].method[-1].atom_parameters
-    assert approx(params[1].hubbard_model.u.magnitude) == 3.2
+    assert approx(params[1].hubbard_model.u.to('eV').magnitude) == 3.2


### PR DESCRIPTION
Please, @ndaelman-hu , this is quickly to review, can you take a look?

Some remarks for the metainfo:

- `orbital` is now MEnum, accepting the orbital angular momentum label, without number.
- ~~electron_volts everywhere~~
- `method` renamed to `double_counting_correction`
- `projection_type` moved as code-specific quantities

Please, also [check the MR in nomad regarding this](https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/issues/1285). I will link it with your [current issue on DFT+U](https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/issues/884).