### PR TITLE
Occupations fix

### DIFF
--- a/electronicparsers/soliddmft/parser.py
+++ b/electronicparsers/soliddmft/parser.py
@@ -189,17 +189,9 @@ class SolidDMFTParser:
         for i in range(sec_dmft.n_atoms_per_unit_cell):
             corr_orbs_per_atoms.append(
                 self.dft_input['corr_shells'][str(i)].get('dim', 1)[()])
-            if sec_method.x_soliddmft_general.x_soliddmft_magnetic:
-                try:
-                    total_occupation = self.dmft_results['observables']['imp_occ'][str(i)]['down']['0'][()] + \
-                        self.dmft_results['observables']['imp_occ'][str(i)]['up']['0'][()]
-                    occ_per_atoms.append(total_occupation)
-                except Exception:
-                    self.logger.warning('The magnetic flag is true, but the occupation per atom is spin independent. '
-                                        'Please check your outputs.')
-                    occ_per_atoms.append(self.dmft_results['observables']['imp_occ'][str(i)]['0'][()])
-            else:
-                occ_per_atoms.append(self.dmft_results['observables']['imp_occ'][str(i)]['0'][()])
+            total_occupation = self.dmft_results['observables']['imp_occ'][str(i)]['down']['0'][()] + \
+                self.dmft_results['observables']['imp_occ'][str(i)]['up']['0'][()]
+            occ_per_atoms.append(total_occupation)
         sec_dmft.n_correlated_orbitals = corr_orbs_per_atoms
         sec_dmft.n_correlated_electrons = occ_per_atoms
         sec_dmft.inverse_temperature = sec_method.x_soliddmft_general.x_soliddmft_beta / ureg.eV

--- a/electronicparsers/soliddmft/parser.py
+++ b/electronicparsers/soliddmft/parser.py
@@ -336,7 +336,7 @@ class SolidDMFTParser:
                 self.logger.warning('Greens function matrices are set up using the number of orbitals from the impurity 0. '
                                     'We found different number of orbitals per impurity. Is this physically correct?')
             setattr(sec_gf, self._gf_map[keys], np.reshape(funct, (nat, 2, norb[0], naxis)))
-        sec_gf.occupancies = np.reshape(sec_scc.scf_iteration[-1].x_soliddmft_observables.x_soliddmft_orb_occ, (nat, 2, norb[0]))
+        sec_gf.orbital_occupations = np.reshape(sec_scc.scf_iteration[-1].x_soliddmft_observables.x_soliddmft_orb_occ, (nat, 2, norb[0]))
         sec_gf.quasiparticle_weights = np.reshape(sec_scc.scf_iteration[-1].x_soliddmft_observables.x_soliddmft_orb_Z, (nat, 2, norb[0]))
 
     def parse(self, filepath, archive, logger):

--- a/electronicparsers/w2dynamics/parser.py
+++ b/electronicparsers/w2dynamics/parser.py
@@ -259,7 +259,7 @@ class W2DynamicsParser:
                 for i in range(nat):
                     parameters.append([[
                         sec_scf_iteration.x_w2dynamics_ineq[0].x_w2dynamics_occ[no, ns, no, ns] for no in range(3)] for ns in range(2)])
-                sec_gf.occupancies = np.array(parameters)
+                sec_gf.orbital_occupations = np.array(parameters)
 
     def parse(self, filepath, archive, logger):
         self.filepath = filepath

--- a/tests/test_soliddmft.py
+++ b/tests/test_soliddmft.py
@@ -95,7 +95,7 @@ def test_srvo3(parser):
     assert sec_gfs.self_energy_iw.shape == (1, 2, 3, 1002)
     assert sec_gfs.greens_function_tau[0][1][1][1025] == approx(-0.14109113749664728 + 0j)
     assert sec_gfs.chemical_potential.magnitude == approx(0.0378235342396917)
-    assert np.sum(sec_gfs.occupancies) == approx(1.008321846227956)
+    assert np.sum(sec_gfs.orbital_occupations) == approx(1.008321846227956)
     assert sec_gfs.quasiparticle_weights.shape == (1, 2, 3)
     assert sec_gfs.quasiparticle_weights[0][0][0] == approx(0.16195076915540912)
     # SCF tests


### PR DESCRIPTION
- Fixing bug in solid_dmft parser when assigning `occ_per_atoms` in paramagnetic systems.
- Changing name `method.dmft.occupancies` to `method.dmft.orbital_occupations`.