### PR TITLE
Hotfix gw workflow method

### DIFF
--- a/electronicparsers/exciting/parser.py
+++ b/electronicparsers/exciting/parser.py
@@ -1804,10 +1804,6 @@ class ExcitingParser:
         for f in ['input_gw.xml', 'input-gw.xml', 'input.xml']:
             self.parse_file(f, sec_method)
 
-        sec_method.basis_set.append(BasisSet(type='(L)APW+lo'))
-        sec_starting_point = sec_method.gw.m_create(XCFunctional)
-        self.parse_xc_functional(sec_starting_point)
-
         # get reference to reference dft calculation
         # dft_archive = None
         # if self.archive.m_context is not None:

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -851,23 +851,12 @@ class FHIAimsParser:
             sec_k_band_segment.occupations = occs
 
     def parse_gw(self):
-        # __Chema comment__:
-        # What is more safe?
-        # 1- Obtain certain sections and quantities again in self.parse_gw()
-        # or 2- Try to work out for dft references IF the data is present in the upload
-        # I think it will be good to have 2-, as this also allows us to keep track whether
-        # an upload is complete or have some missing information.
-        # For now I kept it as having to extract the section 'system' and 'energy.fermi'
-        # again by regex of the output file.
         sec_run = self.archive.run[-1]
 
         # GW method
         sec_method = sec_run.m_create(Method)
         sec_gw = sec_method.m_create(GWMethod)
         sec_gw.type = self._gw_flag_map.get(self.out_parser.get('gw_flag'), None)
-
-        sec_method.basis_set.append(BasisSet(type='numeric AOs'))
-        self.parse_xc_functional(sec_method, sec_gw)
 
         # TODO check this with FHIaims GW developers
         sec_k_mesh = sec_method.m_create(KMesh)

--- a/tests/test_fhiaimsparser.py
+++ b/tests/test_fhiaimsparser.py
@@ -282,7 +282,6 @@ def test_gw_eigs(parser):
 
     assert archive.run[0].system[0].atoms.labels[0] == 'O'
     assert archive.run[0].method[0].gw.type == 'G0W0'
-    assert archive.run[0].method[0].basis_set[0].type == 'numeric AOs'
 
     sec_eigs_gw = archive.run[0].calculation[0].eigenvalues[0]
     assert sec_eigs_gw.value_qp.shape == (1, 1, 81)
@@ -300,8 +299,6 @@ def test_gw_bands(parser):
 
     assert archive.run[0].system[0].atoms.labels == ['Si', 'Si']
     assert archive.run[0].method[0].gw.type == 'G0W0'
-    # assert archive.run[0].method[0].gw.starting_point.exchange[0].name == 'GGA_X_PBE'
-    # assert archive.run[0].method[0].gw.starting_point.correlation[0].name == 'GGA_C_PBE'
 
     sec_scc = archive.run[0].calculation[0]
     assert sec_scc.energy.fermi.to('eV').magnitude == approx(-5.73695796)


### PR DESCRIPTION
Hi,

I just took out the `starting_point` and `basis_set` metainfo from the single point GW. Now the method normalizer (check [1290](https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/issues/1290) in nomad) should be able to capture the proper sections for the elastic search.

@ladinesa can you review this please?