### PR TITLE
18 fhiaims extra method section

### DIFF
--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -1260,6 +1260,7 @@ class FHIAimsParser:
 
             sec_scc = sec_run.m_create(Calculation)
             sec_scc.system_ref = sec_run.system[-1]
+            sec_scc.method_ref = sec_run.method[-1]
 
             sec_energy = sec_scc.m_create(Energy)
             energy = section.get('energy', {})

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -1334,13 +1334,6 @@ class FHIAimsParser:
             # vdW parameters
             parse_vdW(section)
 
-            if self._calculation_type == 'dft':
-                sec_method = sec_run.m_create(Method)
-                sec_scc.method_ref = sec_run.method[-1]
-                sec_method.electronic = Electronic(method='DFT')
-                sec_method.core_method_ref = sec_run.method[0]
-                sec_method.methods_ref = [sec_run.method[0]]
-
         for n, section in enumerate(self.out_parser.get('full_scf', [])):
             # skip frames for large trajectories
             if (n % self.frame_rate) > 0:

--- a/tests/test_fhiaimsparser.py
+++ b/tests/test_fhiaimsparser.py
@@ -62,7 +62,7 @@ def test_scf_spinpol(parser):
     assert archive.run[0].program.version == '151211'
     assert archive.run[0].time_run.wall_start.magnitude == approx(2.23485023e+08)
 
-    assert len(archive.run[0].method) == 2
+    assert len(archive.run[0].method) == 1
     sec_method = archive.run[0].method[0]
     assert sec_method.electronic.n_spin_channels == 2
     assert sec_method.electronic.relativity_method == 'scalar_relativistic_atomic_ZORA'
@@ -102,8 +102,7 @@ def test_geomopt(parser):
     parser.parse('tests/data/fhiaims/Si_geomopt/out.out', archive, None)
 
     sec_methods = archive.run[0].method
-    # one more since 0 is core settings
-    assert len(sec_methods) == 7
+    assert len(sec_methods) == 1
 
     sec_sccs = archive.run[0].calculation
     assert len(sec_sccs) == 6


### PR DESCRIPTION
I've removed the trailing Method section(s) in the FHIaims parser, since 
- it was giving issues with workflows (the bug part).
- it is irrelevant (there should only be one `Method` for DFT).