### PR TITLE
Bump nomad version

### DIFF
--- a/.github/workflows/python-actions.yaml
+++ b/.github/workflows/python-actions.yaml
@@ -26,7 +26,7 @@ jobs:
         python -m pylint --load-plugins=nomad.metainfo.pylint_plugin *parsers tests
     - name: mypy
       run: |
-        python -m mypy --ignore-missing-imports --follow-imports=silent --no-strict-optional *parsers tests
+        python -m mypy *parsers tests
     - name: Test with pytest
       run: |
         python -m pytest -sv tests

--- a/.github/workflows/python-actions.yaml
+++ b/.github/workflows/python-actions.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install nomad-lab==1.0.8 --extra-index-url https://gitlab.mpcdf.mpg.de/api/v4/projects/2187/packages/pypi/simple
+        pip install nomad-lab==1.1.7 --extra-index-url https://gitlab.mpcdf.mpg.de/api/v4/projects/2187/packages/pypi/simple
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install .[tests]
     - name: pycodestyle

--- a/.github/workflows/python-actions.yaml
+++ b/.github/workflows/python-actions.yaml
@@ -23,7 +23,7 @@ jobs:
         python -m pycodestyle --ignore=E501,E701,E731 *parsers tests
     - name: pylint
       run: |
-        python -m pylint *parsers tests
+        python -m pylint --ignore=E0611,E1101 *parsers tests
     - name: mypy
       run: |
         python -m mypy *parsers tests

--- a/.github/workflows/python-actions.yaml
+++ b/.github/workflows/python-actions.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install nomad-lab==1.1.8 --extra-index-url https://gitlab.mpcdf.mpg.de/api/v4/projects/2187/packages/pypi/simple
+        pip install nomad-lab==1.1.7 --extra-index-url https://gitlab.mpcdf.mpg.de/api/v4/projects/2187/packages/pypi/simple
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install .[tests]
     - name: pycodestyle

--- a/.github/workflows/python-actions.yaml
+++ b/.github/workflows/python-actions.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install nomad-lab==1.1.7 --extra-index-url https://gitlab.mpcdf.mpg.de/api/v4/projects/2187/packages/pypi/simple
+        pip install nomad-lab==1.1.8 --extra-index-url https://gitlab.mpcdf.mpg.de/api/v4/projects/2187/packages/pypi/simple
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install .[tests]
     - name: pycodestyle

--- a/.github/workflows/python-actions.yaml
+++ b/.github/workflows/python-actions.yaml
@@ -23,7 +23,7 @@ jobs:
         python -m pycodestyle --ignore=E501,E701,E731 *parsers tests
     - name: pylint
       run: |
-        python -m pylint --load-plugins=nomad.metainfo.pylint_plugin *parsers tests
+        python -m pylint *parsers tests
     - name: mypy
       run: |
         python -m mypy *parsers tests

--- a/.github/workflows/python-actions.yaml
+++ b/.github/workflows/python-actions.yaml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.pylintrc
+++ b/.pylintrc
@@ -3,53 +3,14 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-whitelist=
+extension-pkg-whitelist=pydantic
 
-# Add files or directories to the blacklist. They should be base names, not
-# paths.
-ignore=CVS
-
-# Add files or directories matching the regex patterns to the blacklist. The
-# regex matches against base names, not paths.
-ignore-patterns=
-
-# Python code to execute, usually for sys.path manipulation such as
-# pygtk.require().
-#init-hook=
-
-# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
-# number of processors available to use.
-jobs=1
-
-# Control the amount of potential inferred values when inferring a single
-# object. This can help the performance when dealing with large functions or
-# complex, nested conditions.
-limit-inference-results=100
-
-# List of plugins (as comma separated values of python modules names) to load,
+# List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
-load-plugins=
-
-# Pickle collected data for later comparisons.
-persistent=yes
-
-# Specify a configuration file.
-#rcfile=
-
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
-# Allow loading of arbitrary C extensions. Extensions are imported into the
-# active Python interpreter and may run arbitrary code.
-unsafe-load-any-extension=no
+load-plugins=pylint_mongoengine,nomad.metainfo.pylint_plugin
 
 
 [MESSAGES CONTROL]
-
-# Only show warnings with the listed confidence levels. Leave empty to show
-# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
-confidence=
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
@@ -61,6 +22,7 @@ confidence=
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
 disable=blacklisted-name,
+        unspecified-encoding,
         invalid-name,
         missing-docstring,
         empty-docstring,
@@ -70,6 +32,7 @@ disable=blacklisted-name,
         unidiomatic-typecheck,
         consider-using-enumerate,
         consider-iterating-dictionary,
+        consider-using-f-string,
         bad-classmethod-argument,
         bad-mcs-method-argument,
         bad-mcs-classmethod-argument,
@@ -93,6 +56,7 @@ disable=blacklisted-name,
         ungrouped-imports,
         wrong-import-position,
         useless-import-alias,
+        import-outside-toplevel,
         old-style-class,
         len-as-condition,
         raw-checker-failed,
@@ -277,7 +241,22 @@ disable=blacklisted-name,
         deprecated-sys-function,
         exception-escape,
         comprehension-escape,
-        mongoengine-placeholder
+        mongoengine-placeholder,
+        # TODO: These were temporarily added when upgrading to newer pylint version that
+        # catches these new linting issues. Should be addressed and removed.
+        self-assigning-variable,
+        use-dict-literal,
+        unnecessary-comprehension,
+        use-sequence-for-iteration,
+        f-string-without-interpolation,
+        super-with-arguments,
+        used-before-assignment,
+        consider-using-dict-items,
+        no-else-continue,
+        arguments-renamed,
+        consider-using-with,
+        raise-missing-from,
+        no-else-break
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -402,411 +381,9 @@ enable=syntax-error,
        bad-open-mode
 
 
-[REPORTS]
-
-# Python expression which should return a note less than 10 (10 is the highest
-# note). You have access to the variables errors warning, statement which
-# respectively contain the number of errors / warnings messages and the total
-# number of statements analyzed. This is used by the global evaluation report
-# (RP0004).
-evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
-
-# Template used to display messages. This is a python new-style format string
-# used to format the message information. See doc for all details.
-#msg-template=
-
-# Set the output format. Available formats are text, parseable, colorized, json
-# and msvs (visual studio). You can also give a reporter class, e.g.
-# mypackage.mymodule.MyReporterClass.
-output-format=text
-
-# Tells whether to display a full report or only the messages.
-reports=no
-
-# Activate the evaluation score.
-score=yes
-
-
-[REFACTORING]
-
-# Maximum number of nested blocks for function / method body
-max-nested-blocks=5
-
-# Complete name of functions that never returns. When checking for
-# inconsistent-return-statements if a never returning function is called then
-# it will be considered as an explicit return statement and no message will be
-# printed.
-never-returning-functions=sys.exit
-
-
-[BASIC]
-
-# Naming style matching correct argument names.
-argument-naming-style=snake_case
-
-# Regular expression matching correct argument names. Overrides argument-
-# naming-style.
-#argument-rgx=
-
-# Naming style matching correct attribute names.
-attr-naming-style=snake_case
-
-# Regular expression matching correct attribute names. Overrides attr-naming-
-# style.
-#attr-rgx=
-
-# Bad variable names which should always be refused, separated by a comma.
-bad-names=foo,
-          bar,
-          baz,
-          toto,
-          tutu,
-          tata
-
-# Naming style matching correct class attribute names.
-class-attribute-naming-style=any
-
-# Regular expression matching correct class attribute names. Overrides class-
-# attribute-naming-style.
-#class-attribute-rgx=
-
-# Naming style matching correct class names.
-class-naming-style=PascalCase
-
-# Regular expression matching correct class names. Overrides class-naming-
-# style.
-#class-rgx=
-
-# Naming style matching correct constant names.
-const-naming-style=UPPER_CASE
-
-# Regular expression matching correct constant names. Overrides const-naming-
-# style.
-#const-rgx=
-
-# Minimum line length for functions/classes that require docstrings, shorter
-# ones are exempt.
-docstring-min-length=-1
-
-# Naming style matching correct function names.
-function-naming-style=snake_case
-
-# Regular expression matching correct function names. Overrides function-
-# naming-style.
-#function-rgx=
-
-# Good variable names which should always be accepted, separated by a comma.
-good-names=i,
-           j,
-           k,
-           ex,
-           Run,
-           _
-
-# Include a hint for the correct naming format with invalid-name.
-include-naming-hint=no
-
-# Naming style matching correct inline iteration names.
-inlinevar-naming-style=any
-
-# Regular expression matching correct inline iteration names. Overrides
-# inlinevar-naming-style.
-#inlinevar-rgx=
-
-# Naming style matching correct method names.
-method-naming-style=snake_case
-
-# Regular expression matching correct method names. Overrides method-naming-
-# style.
-#method-rgx=
-
-# Naming style matching correct module names.
-module-naming-style=snake_case
-
-# Regular expression matching correct module names. Overrides module-naming-
-# style.
-#module-rgx=
-
-# Colon-delimited sets of names that determine each other's naming style when
-# the name regexes allow several styles.
-name-group=
-
-# Regular expression which should only match function or class names that do
-# not require a docstring.
-no-docstring-rgx=^_
-
-# List of decorators that produce properties, such as abc.abstractproperty. Add
-# to this list to register other decorators that produce valid properties.
-# These decorators are taken in consideration only for invalid-name.
-property-classes=abc.abstractproperty
-
-# Naming style matching correct variable names.
-variable-naming-style=snake_case
-
-# Regular expression matching correct variable names. Overrides variable-
-# naming-style.
-#variable-rgx=
-
-
-[FORMAT]
-
-# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
-expected-line-ending-format=
-
-# Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*(# )?<?https?://\S+>?$
-
-# Number of spaces of indent required inside a hanging  or continued line.
-indent-after-paren=4
-
-# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
-# tab).
-indent-string='    '
-
-# Maximum number of characters on a single line.
-max-line-length=100
-
-# Maximum number of lines in a module.
-max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
-
-# Allow the body of a class to be on the same line as the declaration if body
-# contains single statement.
-single-line-class-stmt=no
-
-# Allow the body of an if to be on the same line as the test if there is no
-# else.
-single-line-if-stmt=no
-
-
-[LOGGING]
-
-# Logging modules to check that the string format arguments are in logging
-# function parameter format.
-logging-modules=logging
-
-
-[MISCELLANEOUS]
-
-# List of note tags to take in consideration, separated by a comma.
-notes=FIXME,
-      XXX,
-      TODO
-
-
-[SIMILARITIES]
-
-# Ignore comments when computing similarities.
-ignore-comments=yes
-
-# Ignore docstrings when computing similarities.
-ignore-docstrings=yes
-
-# Ignore imports when computing similarities.
-ignore-imports=no
-
-# Minimum lines number of a similarity.
-min-similarity-lines=4
-
-
-[SPELLING]
-
-# Limits count of emitted suggestions for spelling mistakes.
-max-spelling-suggestions=4
-
-# Spelling dictionary name. Available dictionaries: none. To make it working
-# install python-enchant package..
-spelling-dict=
-
-# List of comma separated words that should not be checked.
-spelling-ignore-words=
-
-# A path to a file that contains private dictionary; one word per line.
-spelling-private-dict-file=
-
-# Tells whether to store unknown words to indicated private dictionary in
-# --spelling-private-dict-file option instead of raising a message.
-spelling-store-unknown-words=no
-
-
 [TYPECHECK]
-
-# List of decorators that produce context managers, such as
-# contextlib.contextmanager. Add to this list to register other decorators that
-# produce valid context managers.
-contextmanager-decorators=contextlib.contextmanager
-
-# List of members which are set dynamically and missed by pylint inference
-# system, and so shouldn't trigger E1101 when accessed. Python regular
-# expressions are accepted.
-generated-members=
-
-# Tells whether missing members accessed in mixin class should be ignored. A
-# mixin class is detected if its name ends with "mixin" (case insensitive).
-ignore-mixin-members=yes
-
-# Tells whether to warn about missing members when the owner of the attribute
-# is inferred to be None.
-ignore-none=yes
-
-# This flag controls whether pylint should warn about no-member and similar
-# checks whenever an opaque object is returned when inferring. The inference
-# can return multiple potential results while evaluating a Python object, but
-# some branches might not be evaluated, which results in partial inference. In
-# that case, it might be useful to still emit no-member and other checks for
-# the rest of the inferred objects.
-ignore-on-opaque-inference=yes
 
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of
 # qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local
-
-# List of module names for which member attributes should not be checked
-# (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis. It
-# supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
-
-# Show a hint with possible names when a member name was not found. The aspect
-# of finding the hint is based on edit distance.
-missing-member-hint=yes
-
-# The minimum edit distance a name should have in order to be considered a
-# similar match for a missing member name.
-missing-member-hint-distance=1
-
-# The total number of similar names that should be taken in consideration when
-# showing a hint for a missing member.
-missing-member-max-choices=1
-
-
-[VARIABLES]
-
-# List of additional names supposed to be defined in builtins. Remember that
-# you should avoid to define new builtins when possible.
-additional-builtins=
-
-# Tells whether unused global variables should be treated as a violation.
-allow-global-unused-variables=yes
-
-# List of strings which can identify a callback function by name. A callback
-# name must start or end with one of those strings.
-callbacks=cb_,
-          _cb
-
-# A regular expression matching the name of dummy variables (i.e. expected to
-# not be used).
-dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
-
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore.
-ignored-argument-names=_.*|^ignored_|^unused_
-
-# Tells whether we should check for unused import in __init__ files.
-init-import=no
-
-# List of qualified module names which can have objects that can redefine
-# builtins.
-redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
-
-
-[CLASSES]
-
-# List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods=__init__,
-                      __new__,
-                      setUp
-
-# List of member names, which should be excluded from the protected access
-# warning.
-exclude-protected=_asdict,
-                  _fields,
-                  _replace,
-                  _source,
-                  _make
-
-# List of valid names for the first argument in a class method.
-valid-classmethod-first-arg=cls
-
-# List of valid names for the first argument in a metaclass class method.
-valid-metaclass-classmethod-first-arg=cls
-
-
-[DESIGN]
-
-# Maximum number of arguments for function / method.
-max-args=5
-
-# Maximum number of attributes for a class (see R0902).
-max-attributes=7
-
-# Maximum number of boolean expressions in an if statement.
-max-bool-expr=5
-
-# Maximum number of branch for function / method body.
-max-branches=12
-
-# Maximum number of locals for function / method body.
-max-locals=15
-
-# Maximum number of parents for a class (see R0901).
-max-parents=7
-
-# Maximum number of public methods for a class (see R0904).
-max-public-methods=20
-
-# Maximum number of return / yield for function / method body.
-max-returns=6
-
-# Maximum number of statements in function / method body.
-max-statements=50
-
-# Minimum number of public methods for a class (see R0903).
-min-public-methods=2
-
-
-[IMPORTS]
-
-# Allow wildcard imports from modules that define __all__.
-allow-wildcard-with-all=no
-
-# Analyse import fallback blocks. This can be used to support both Python 2 and
-# 3 compatible code, which means that the block might have code that exists
-# only in one or another interpreter, leading to false positives when analysed.
-analyse-fallback-blocks=no
-
-# Deprecated modules which should not be used, separated by a comma.
-deprecated-modules=optparse,tkinter.tix
-
-# Create a graph of external dependencies in the given file (report RP0402 must
-# not be disabled).
-ext-import-graph=
-
-# Create a graph of every (i.e. internal and external) dependencies in the
-# given file (report RP0402 must not be disabled).
-import-graph=
-
-# Create a graph of internal dependencies in the given file (report RP0402 must
-# not be disabled).
-int-import-graph=
-
-# Force import order to recognize a module as part of the standard
-# compatibility libraries.
-known-standard-library=
-
-# Force import order to recognize a module as part of a third party library.
-known-third-party=enchant
-
-
-[EXCEPTIONS]
-
-# Exceptions that will emit a warning when being caught. Defaults to
-# "Exception".
-overgeneral-exceptions=Exception
+ignored-classes=optparse.Values,thread._local,_thread._local,SearchResponse

--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,7 @@ extension-pkg-whitelist=pydantic
 
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
-load-plugins=pylint_mongoengine,nomad.metainfo.pylint_plugin
+load-plugins=
 
 
 [MESSAGES CONTROL]

--- a/electronicparsers/abinit/parser.py
+++ b/electronicparsers/abinit/parser.py
@@ -28,7 +28,7 @@ from nomad.parsing.file_parser.text_parser import TextParser, Quantity, DataText
 from nomad.datamodel.metainfo.simulation.run import Run, Program, TimeRun
 from nomad.datamodel.metainfo.simulation.method import (
     Method, BasisSet, BasisSetCellDependent, Electronic, Smearing, Scf, DFT, XCFunctional,
-    Functional, KMesh, GW as GWMethod)
+    Functional, KMesh)
 from nomad.datamodel.metainfo.simulation.system import System, Atoms
 from nomad.datamodel.metainfo.simulation.calculation import (
     Calculation, Energy, EnergyEntry, Forces, ForcesEntry, Stress, StressEntry, Dos,
@@ -1028,30 +1028,7 @@ class AbinitParser(BeyondDFTWorkflowsParser):
                     pass
 
     def parse_gw(self):
-        sec_run = self.archive.run[-1]
-
-        # TODO parse GW method entry
-        # Method
-        sec_method = sec_run.m_create(Method)
-        # KMesh
-        sec_k_mesh = sec_method.m_create(KMesh)
-        # sec_k_mesh.grid = ...
-        # GW
-        sec_gw = sec_method.m_create(GWMethod)
-        # sec_gw.type = ...
-        # sec_gw.q_grid = sec_k_mesh?
-        # sec_gw.self_energy_analytical_continuation = ...
-        # sec_gw.n_frequencies = ...
-        # sec_gw.frequency_values = ...
-        # sec_gw.core_treatment = ...
-        # sec_gw.dielectric_function_treatment = ...
-        # sec_gw.n_empty_states_polarizability = ...
-        # sec_gw.n_empty_states_self_energy = ...
-
-        # GW calculation
-        sec_scc = sec_run.m_create(Calculation)
-        sec_scc.method_ref = sec_method
-        sec_scc.system_ref = sec_run.system[-1]
+        pass
 
     def parse_workflow(self):
         sec_workflow = self.archive.m_create(Workflow)

--- a/electronicparsers/fleur/parser.py
+++ b/electronicparsers/fleur/parser.py
@@ -508,7 +508,7 @@ class FleurParser:
         if input is not None:
             for key in ['parameters', 'input_parameters']:
                 setattr(sec_method, f'x_fleur_{key}', {
-                    key: list([float(v) for v in val]) if isinstance(
+                    key: list(float(v) for v in val) if isinstance(
                         val, np.ndarray) else val for key, val in input.get(key, {}).get('key_val', [])})
         if not sec_method.x_fleur_parameters:
             sec_method.x_fleur_parameters = {}

--- a/electronicparsers/fplo/metainfo/fplo.py
+++ b/electronicparsers/fplo/metainfo/fplo.py
@@ -123,7 +123,7 @@ class Method(simulation.method.Method):
         ''')
 
 
-class HubbardModel(simulation.method.HubbardModel):
+class HubbardModel(simulation.method.HubbardKanamoriModel):
 
     m_def = Section(validate=False, extends_base_section=True)
 

--- a/electronicparsers/orca/parser.py
+++ b/electronicparsers/orca/parser.py
@@ -610,7 +610,7 @@ class OrcaParser:
                     val = basis_set.get(key)
                     if val is None:
                         continue
-                    prefix = '' if key == 'basis_set_atom_labels' else kind.split('basis_set')[0]
+                    prefix = '' if key == 'basis_set_atom_labels' else kind.split('basis_set', maxsplit=1)[0]
                     metainfo_name = 'x_orca_%s%s' % (prefix, key)
                     setattr(sec_basis_set, metainfo_name, val[n])
 

--- a/electronicparsers/psi4/parser.py
+++ b/electronicparsers/psi4/parser.py
@@ -846,7 +846,7 @@ class Psi4Parser:
             calculations_ref = []
             for name in module_names:
                 for submodule in module.get(name, []):
-                    self._method = submodule.get('method', name.split('_')[0].upper())
+                    self._method = submodule.get('method', name.split('_', maxsplit=1)[0].upper())
                     self.parse_system(submodule)
                     self.parse_method(submodule)
                     calc = self.parse_calculation(submodule)

--- a/electronicparsers/qball/parser.py
+++ b/electronicparsers/qball/parser.py
@@ -31,7 +31,7 @@ from nomad.datamodel.metainfo.simulation.method import Method, BasisSet
 from nomad.datamodel.metainfo.simulation.calculation import Calculation, Forces, ForcesEntry
 from nomad.parsing.file_parser import Quantity, TextParser
 
-import xml.etree.ElementTree as ElementTree
+import xml.etree.ElementTree as ElementTreeXML
 
 
 def str_to_timestamp(s: str):
@@ -94,7 +94,7 @@ class QBallParser:
             basis_set = method.m_create(BasisSet)
             basis_set.type = "plane waves"
 
-        element_tree = ElementTree.fromstring(contents)
+        element_tree = ElementTreeXML.fromstring(contents)
 
         # system
         system = run.m_create(System)

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -190,7 +190,7 @@ class ContentParser:
         return val
 
     def is_converged(self, n_calc):
-        return
+        return False
 
 
 class OutcarTextParser(TextParser):

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+strict = false
+ignore_missing_imports = true
+follow_imports = silent
+no_strict_optional = true
+disable_error_code = import, annotation-unchecked

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 authors = [{ name = "The NOMAD Authors" }]
 license = { file = "LICENSE" }
 dependencies = [
-    # "nomad-lab[infrastrucutre]",
+    # "nomad-lab",
     "lxml==4.7.1",
     "pyscf==2.0.1; sys_platform == 'darwin'",
     "netCDF4==1.5.4",
@@ -22,7 +22,7 @@ homepage = "https://github.com/nomad-coe/electronic-parsers"
 
 [project.optional-dependencies]
 tests = [
-    'mypy>=0.750',
+    'mypy',
     'pylint>=2.3.1',
     'pylint_plugin_utils>=0.5',
     'pycodestyle==2.8.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,14 +22,14 @@ homepage = "https://github.com/nomad-coe/electronic-parsers"
 
 [project.optional-dependencies]
 tests = [
-    'mypy==0.750',
-    'pylint==2.3.1',
-    'pylint_plugin_utils==0.5',
+    'mypy>=0.750',
+    'pylint>=2.3.1',
+    'pylint_plugin_utils>=0.5',
     'pycodestyle==2.8.0',
     'pytest==3.10.0',
     'pytest-timeout==1.4.2',
     'pytest-cov==2.7.1',
-    'astroid==2.5.1'
+    'astroid>=2.5.1'
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ homepage = "https://github.com/nomad-coe/electronic-parsers"
 
 [project.optional-dependencies]
 tests = [
-    'mypy',
-    'pylint>=2.3.1',
-    'pylint_plugin_utils>=0.5',
+    'mypy==1.0.1',
+    'pylint==2.13.9',
+    'pylint_plugin_utils==0.7',
     'pycodestyle==2.8.0',
     'pytest==3.10.0',
     'pytest-timeout==1.4.2',

--- a/tests/test_openmxparser.py
+++ b/tests/test_openmxparser.py
@@ -79,7 +79,7 @@ def test_HfO2(parser):
     assert method.dft.xc_functional.exchange[0].name == 'GGA_X_PBE'
 
     system = run.system[0]
-    assert all([a == b for a, b in zip(system.atoms.periodic, [True, True, True])])
+    assert all(a == b for a, b in zip(system.atoms.periodic, [True, True, True]))
     assert system.atoms.lattice_vectors[0][0].magnitude == approx(A_to_m(5.1156000))
     assert system.atoms.lattice_vectors[2][2].magnitude == approx(A_to_m(5.2269843))
     assert len(system.atoms.positions) == 12
@@ -130,7 +130,7 @@ def test_AlN(parser):
 
     assert len(run.system) == 5
     system = run.system[0]
-    assert all([a == b for a, b in zip(system.atoms.periodic, [True, True, True])])
+    assert all(a == b for a, b in zip(system.atoms.periodic, [True, True, True]))
     assert system.atoms.lattice_vectors[0][0].magnitude == approx(A_to_m(3.10997))
     assert system.atoms.lattice_vectors[1][0].magnitude == approx(A_to_m(-1.55499))
     assert len(system.atoms.positions) == 4
@@ -212,7 +212,7 @@ def test_C2N2(parser):
     eigenvalues = run.calculation[-1].eigenvalues[0]
     assert eigenvalues.n_kpoints == 1
     assert np.shape(eigenvalues.kpoints) == (1, 3)
-    assert all([a == pytest.approx(b) for a, b in zip(eigenvalues.kpoints[0], [0, 0, 0])])
+    assert all(a == pytest.approx(b) for a, b in zip(eigenvalues.kpoints[0], [0, 0, 0]))
     assert np.shape(eigenvalues.energies) == (1, 1, 64)
     assert eigenvalues.energies[0, 0, 0].magnitude == approx(Ha_to_J(-0.67352892393426))
     assert eigenvalues.energies[0, 0, 63].magnitude == approx(Ha_to_J(7.29352095903235))


### PR DESCRIPTION
@ladinesa @ndaelman-hu @fekad 

Hi, I was playing a bit trying to bump the nomad-lab version and push to Python 3.9.

As you can see, the pipeline still fails in pylint. My question for all of you would be: should we ignore E0611 and E1101 (including it in .pylintrc)? The main reason of why to do this would be that the parsers have to adapt to the tag of nomad-lab, which sometimes is behind of what we are implementing.

Risk is: we might commit mistakes when importing, but I guess this can be reflected with other errors in the pipeline?

Let me know what you think.