### PR TITLE
Rework GW and BSE method

### DIFF
--- a/electronicparsers/abinit/parser.py
+++ b/electronicparsers/abinit/parser.py
@@ -1087,11 +1087,11 @@ class AbinitParser(BeyondDFTWorkflowsParser):
             else:
                 sec_gw.analytical_continuation = 'contour_deformation'
         # FrequencyMesh
-        if self.out_parser.get('screening_dataset'):
-            if self.out_parser.get('screening_dataset').get('frequencies'):
-                freqs = self.out_parser.get('screening_dataset').get('frequencies').get('values') * ureg.eV
-                values = freqs[:, 0] + freqs[:, 1] * 1j
-                sec_freq_mesh = FrequencyMesh(n_points=len(freqs), values=values)
+        frequency_values = self.out_parser.get('screening_dataset', {}).get('frequencies', {}).get('values')
+        if frequency_values is not None:
+            freqs = frequency_values * ureg.eV
+            values = freqs[:, 0] + freqs[:, 1] * 1j
+            sec_freq_mesh = FrequencyMesh(n_points=len(freqs), values=values)
         else:
             freq_plasma = self.out_parser.get('gw_dataset', {}).get('omega_plasma', 0.0)
             values = [0.0, freq_plasma * 1j]
@@ -1102,7 +1102,7 @@ class AbinitParser(BeyondDFTWorkflowsParser):
         n_scr = len(occ_scr)
         n_occ_scr = len([occ for occ in occ_scr if occ > 0.0])
         n_empty_scr = n_scr - n_occ_scr
-        sec_screening = Screening(n_empty_states=n_empty_scr)
+        sec_screening = Screening(n_states=n_scr, n_empty_states=n_empty_scr)
         sec_gw.m_add_sub_section(GW.screening, sec_screening)
         # Other paramters
         if self.out_parser.get_input_var('bdgw', 4, np.array(None)).all():

--- a/electronicparsers/abinit/parser.py
+++ b/electronicparsers/abinit/parser.py
@@ -1091,23 +1091,18 @@ class AbinitParser(BeyondDFTWorkflowsParser):
             if self.out_parser.get('screening_dataset').get('frequencies'):
                 freqs = self.out_parser.get('screening_dataset').get('frequencies').get('values') * ureg.eV
                 values = freqs[:, 0] + freqs[:, 1] * 1j
-                sec_freq_mesh = FreqMesh(
-                    n_points=len(freqs),
-                    values=values)
+                sec_freq_mesh = FreqMesh(n_points=len(freqs), values=values)
         else:
-            freq_plasma = self.out_parser.get('gw_dataset').get('omega_plasma', 0.0)
+            freq_plasma = self.out_parser.get('gw_dataset', {}).get('omega_plasma', 0.0)
             values = [0.0, freq_plasma * 1j]
-            sec_freq_mesh = FreqMesh(
-                n_points=2,
-                values=values)
+            sec_freq_mesh = FreqMesh(n_points=2, values=values)
         sec_gw.m_add_sub_section(GW.frequency_mesh, sec_freq_mesh)
         # Screening
         occ_scr = self.out_parser.get_input_var('occ', 3, [])
         n_scr = len(occ_scr)
-        n_occ_scr = len([occ_scr[i] for i in range(n_scr) if occ_scr[i] > 0.0])
+        n_occ_scr = len([occ for occ in occ_scr if occ > 0.0])
         n_empty_scr = n_scr - n_occ_scr
-        sec_screening = Screening(
-            n_empty_states=n_empty_scr)
+        sec_screening = Screening(n_empty_states=n_empty_scr)
         sec_gw.m_add_sub_section(GW.screening, sec_screening)
         # Other paramters
         if self.out_parser.get_input_var('bdgw', 4, np.array(None)).all():

--- a/electronicparsers/abinit/parser.py
+++ b/electronicparsers/abinit/parser.py
@@ -1105,9 +1105,9 @@ class AbinitParser(BeyondDFTWorkflowsParser):
         occ_scr = self.out_parser.get_input_var('occ', 3, [])
         n_scr = len(occ_scr)
         n_occ_scr = len([occ_scr[i] for i in range(n_scr) if occ_scr[i] > 0.0])
+        n_empty_scr = n_scr - n_occ_scr
         sec_screening = Screening(
-            n_empty_states = n_scr - n_occ_scr
-        )
+            n_empty_states=n_empty_scr)
         sec_gw.m_add_sub_section(GW.screening, sec_screening)
         # Other paramters
         if self.out_parser.get_input_var('bdgw', 4, np.array(None)).all():

--- a/electronicparsers/abinit/parser.py
+++ b/electronicparsers/abinit/parser.py
@@ -28,7 +28,7 @@ from nomad.parsing.file_parser.text_parser import TextParser, Quantity, DataText
 from nomad.datamodel.metainfo.simulation.run import Run, Program, TimeRun
 from nomad.datamodel.metainfo.simulation.method import (
     Method, BasisSet, BasisSetCellDependent, Electronic, Smearing, Scf, DFT, XCFunctional,
-    Functional, KMesh, FreqMesh, Screening, GW)
+    Functional, KMesh, FrequencyMesh, Screening, GW)
 from nomad.datamodel.metainfo.simulation.system import System, Atoms
 from nomad.datamodel.metainfo.simulation.calculation import (
     Calculation, Energy, EnergyEntry, Forces, ForcesEntry, Stress, StressEntry, Dos,
@@ -1086,16 +1086,16 @@ class AbinitParser(BeyondDFTWorkflowsParser):
                 sec_gw.analytical_continuation = 'ppm_FaridEngel'
             else:
                 sec_gw.analytical_continuation = 'contour_deformation'
-        # FreqMesh
+        # FrequencyMesh
         if self.out_parser.get('screening_dataset'):
             if self.out_parser.get('screening_dataset').get('frequencies'):
                 freqs = self.out_parser.get('screening_dataset').get('frequencies').get('values') * ureg.eV
                 values = freqs[:, 0] + freqs[:, 1] * 1j
-                sec_freq_mesh = FreqMesh(n_points=len(freqs), values=values)
+                sec_freq_mesh = FrequencyMesh(n_points=len(freqs), values=values)
         else:
             freq_plasma = self.out_parser.get('gw_dataset', {}).get('omega_plasma', 0.0)
             values = [0.0, freq_plasma * 1j]
-            sec_freq_mesh = FreqMesh(n_points=2, values=values)
+            sec_freq_mesh = FrequencyMesh(n_points=2, values=values)
         sec_gw.m_add_sub_section(GW.frequency_mesh, sec_freq_mesh)
         # Screening
         occ_scr = self.out_parser.get_input_var('occ', 3, [])

--- a/electronicparsers/exciting/metainfo/exciting.py
+++ b/electronicparsers/exciting/metainfo/exciting.py
@@ -2541,6 +2541,22 @@ class Method(simulation.method.Method):
         Type of excited states calculation, BSE or TDDFT
         ''')
 
+    x_exciting_xs_energywindow_values = Quantity(
+        type=np.float64,
+        shape=[2],
+        unit='joule',
+        description='''
+        Energy interval lower and upper limits. Default is [-0.5d0, 0.5d0] in Hartree.
+        ''')
+
+    x_exciting_xs_energywindow_points = Quantity(
+        type=np.int32,
+        shape=[],
+        description='''
+        Number of points to be sampled linearly inside the energy interval including the
+        lower limit. Default is 500.
+        ''')
+
 
 class Run(simulation.run.Run):
 

--- a/electronicparsers/exciting/parser.py
+++ b/electronicparsers/exciting/parser.py
@@ -26,7 +26,8 @@ from nomad.parsing.file_parser import TextParser, Quantity, XMLParser, DataTextP
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
     Method, DFT, Electronic, Smearing, XCFunctional, Functional,
-    GW as GWMethod, Scf, BasisSet, KMesh, FreqMesh, Photon, BSE, CoreHole
+    GW as GWMethod, Scf, BasisSet, KMesh, FreqMesh, Photon, BSE, CoreHole,
+    ExcitedStateMethodology, Screening
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
@@ -1510,7 +1511,12 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
         sec_method.x_exciting_xs_scissor = self.input_xml_parser.get('xs/scissor', 0.0)
         sec_method.x_exciting_xs_vkloff = self.input_xml_parser.get('xs/vkloff', [0., 0., 0.])
 
-        # TODO I am not certain if screening/BSE are children of xs
+        if self.input_xml_parser.get('xs/energywindow') is not None:
+            sec_method.x_exciting_xs_energywindow_values = self.input_xml_parser.get(
+                'xs/energywindow/intv', np.array([-0.5, 0.5]), 'hartree')
+            sec_method.x_exciting_xs_energywindow_points = self.input_xml_parser.get(
+                'xs/energywindow/points', 500)
+
         if self.input_xml_parser.get('xs/screening') is not None:
             sec_method.x_exciting_xs_screening_number_of_empty_states = self.input_xml_parser.get(
                 'xs/screening/nempty', 0)
@@ -1780,25 +1786,40 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
         # Code-specific
         self.parse_file('input.xml', sec_method, self._xs_info_file)
 
-        # KMesh
-        sec_k_mesh = sec_method.m_create(KMesh)
-        sec_k_mesh.grid = sec_run.method[0].get('x_exciting_xs_ngridk')
-
         # BSE
         sec_bse = sec_method.m_create(BSE)
-        sec_bse.n_empty_states = sec_run.method[0].get('x_exciting_xs_number_of_empty_states')
-        sec_bse.screening_type = sec_run.method[0].get('x_exciting_xs_screening_type')
-        sec_bse.n_empty_states_screening = sec_run.method[0].get('x_exciting_xs_screening_number_of_empty_states')
-        sec_bse.k_mesh_screening = KMesh(grid=sec_run.method[0].get('x_exciting_xs_screening_ngridk'))
+        sec_bse.type = sec_run.method[-1].get('x_exciting_xs_bse_type')
+        sec_bse.n_empty_states = sec_run.method[-1].get('x_exciting_xs_number_of_empty_states')
+        sec_bse.broadening = sec_run.method[-1].get('x_exciting_xs_broadening')
+        # KMesh
+        sec_k_mesh = sec_method.m_create(KMesh)
+        sec_k_mesh.grid = sec_run.method[-1].get('x_exciting_xs_ngridk')
+        # QMesh
+        sec_q_mesh = KMesh(grid=sec_run.method[-1].get('x_exciting_xs_ngridq'))
+        sec_bse.m_add_sub_section(BSE.q_mesh, sec_q_mesh)
+        # FreqMesh
+        n_freqs = sec_run.method[-1].get('x_exciting_xs_energywindow_points')
+        freqs = sec_run.method[-1].get('x_exciting_xs_energywindow_values')
+        values = [freqs[0] + i * (freqs[-1] - freqs[0]) / n_freqs for i in range(n_freqs)]
+        sec_freq_mesh = FreqMesh(
+            n_points=n_freqs,
+            values=values)
+        sec_bse.m_add_sub_section(BSE.frequency_mesh, sec_freq_mesh)
+        # Screening
+        sec_screening = Screening(
+            type=sec_run.method[-1].get('x_exciting_xs_screening_type'),
+            n_empty_states=sec_run.method[-1].get('x_exciting_xs_screening_number_of_empty_states'))
+        sec_k_mesh_screening = KMesh(grid=sec_run.method[-1].get('x_exciting_xs_screening_ngridk'))
+        sec_screening.m_add_sub_section(Screening.k_mesh, sec_k_mesh_screening)
+
         # CoreHole
-        sec_core = sec_bse.m_create(CoreHole)
-        if sec_run.method[0].get('x_exciting_xs_bse_xas'):
-            sec_core.mode = 'absorption'
-        elif sec_run.method[0].get('x_exciting_xs_bse_xes'):
-            sec_core.mode = 'emission'
-        sec_core.solver = sec_run.method[0].get('x_exciting_xs_bse_type')
-        sec_core.edge = sec_run.method[0].get('x_exciting_xs_bse_xasedge')
-        sec_core.broadening = ureg.convert(sec_run.method[0].get('x_exciting_xs_broadening'), 'joule', 'electron_volt')
+        if sec_run.method[-1].get('x_exciting_xs_bse_xas'):
+            sec_core = CoreHole(
+                mode='absorption',
+                broadening=sec_run.method[-1].get('x_exciting_xs_broadening'))
+            sec_bse.m_add_sub_section(BSE.core, sec_core)
+            # TODO wait for new changes in metainfo for CoreHole
+            # sec_core.edge = sec_run.method[0].get('x_exciting_xs_bse_xasedge')
 
     def parse_spectra(self, path):
         input_file = get_files('input.xml', self._xs_info_file, 'INFO.OUT')

--- a/electronicparsers/exciting/parser.py
+++ b/electronicparsers/exciting/parser.py
@@ -25,9 +25,9 @@ from nomad.units import ureg
 from nomad.parsing.file_parser import TextParser, Quantity, XMLParser, DataTextParser
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
-    Method, DFT, Electronic, Smearing, XCFunctional, Functional,
-    GW as GWMethod, Scf, BasisSet, KMesh, FreqMesh, Photon, BSE, CoreHole,
-    ExcitedStateMethodology, Screening
+    Method, DFT, Electronic, Smearing, XCFunctional, Functional, Screening,
+    GW as GWMethod, Scf, BasisSet, KMesh, FreqMesh, Photon, BSE, CoreHole
+
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms

--- a/electronicparsers/exciting/parser.py
+++ b/electronicparsers/exciting/parser.py
@@ -1789,7 +1789,7 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
         sec_bse = sec_method.m_create(BSE)
         sec_bse.type = sec_run.method[-1].get('x_exciting_xs_bse_type')
         sec_bse.n_empty_states = sec_run.method[-1].get('x_exciting_xs_number_of_empty_states')
-        sec_bse.broadening = sec_run.method[-1].get('x_exciting_xs_broadening')
+        sec_bse.broadening = sec_run.method[-1].get('x_exciting_xs_broadening') * ureg.hartree
         # KMesh
         sec_k_mesh = sec_method.m_create(KMesh)
         sec_k_mesh.grid = sec_run.method[-1].get('x_exciting_xs_ngridk')
@@ -1815,7 +1815,7 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
         if sec_run.method[-1].get('x_exciting_xs_bse_xas'):
             sec_core = CoreHole(
                 mode='absorption',
-                broadening=sec_run.method[-1].get('x_exciting_xs_broadening'))
+                broadening=sec_run.method[-1].get('x_exciting_xs_broadening') * ureg.hartree)
             sec_bse.m_add_sub_section(BSE.core, sec_core)
             # TODO wait for new changes in metainfo for CoreHole
             # sec_core.edge = sec_run.method[0].get('x_exciting_xs_bse_xasedge')
@@ -1931,7 +1931,6 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
             q_mesh=sec_k_mesh.m_copy(),
             frequency_mesh=sec_freq_mesh.m_copy())
         sec_gw.m_add_sub_section(GW.screening, sec_screening)
-
         # Other parameters
         sec_gw.interval_qp_corrections = [sec_gw.x_exciting_ibgw, sec_gw.x_exciting_nbgw]
         if sec_screening.n_empty_states == 0:

--- a/electronicparsers/exciting/parser.py
+++ b/electronicparsers/exciting/parser.py
@@ -1925,9 +1925,9 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
         sec_screening = Screening(
             type=sec_gw.x_exciting_scrcoul.x_exciting_scrtype,
             n_empty_states=sec_gw.x_exciting_nempty,
-            k_mesh=sec_k_mesh.m_copy(),
-            q_mesh=sec_k_mesh.m_copy(),
-            frequency_mesh=sec_freq_mesh.m_copy())
+            k_mesh=sec_k_mesh,
+            q_mesh=sec_k_mesh,
+            frequency_mesh=sec_freq_mesh)
         sec_gw.m_add_sub_section(GW.screening, sec_screening)
         # Other parameters
         sec_gw.interval_qp_corrections = [sec_gw.x_exciting_ibgw, sec_gw.x_exciting_nbgw]

--- a/electronicparsers/exciting/parser.py
+++ b/electronicparsers/exciting/parser.py
@@ -26,7 +26,7 @@ from nomad.parsing.file_parser import TextParser, Quantity, XMLParser, DataTextP
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
     Method, DFT, Electronic, Smearing, XCFunctional, Functional, Scf, BasisSet, KMesh,
-    FreqMesh, Screening, GW, Photon, BSE, CoreHole
+    FrequencyMesh, Screening, GW, Photon, BSE, CoreHole
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
@@ -1796,11 +1796,11 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
         # QMesh
         sec_q_mesh = KMesh(grid=sec_run.method[-1].get('x_exciting_xs_ngridq'))
         sec_bse.m_add_sub_section(BSE.q_mesh, sec_q_mesh)
-        # FreqMesh
+        # FrequencyMesh
         n_freqs = sec_run.method[-1].get('x_exciting_xs_energywindow_points')
         freqs = sec_run.method[-1].get('x_exciting_xs_energywindow_values')
         values = [freqs[0] + i * (freqs[-1] - freqs[0]) / n_freqs for i in range(n_freqs)]
-        sec_freq_mesh = FreqMesh(n_points=n_freqs, values=values)
+        sec_freq_mesh = FrequencyMesh(n_points=n_freqs, values=values)
         sec_bse.m_add_sub_section(BSE.frequency_mesh, sec_freq_mesh)
         # Screening
         sec_screening = Screening(
@@ -1909,13 +1909,13 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
                     sec_gw.analytical_continuation = 'ppm_GodbyNeeds'
                 else:
                     self.logger.warning('Could not find the analytical continuation method.')
-        # FreqMesh
+        # FrequencyMesh
         n_freqs = sec_gw.x_exciting_freqgrid.x_exciting_nomeg
         freqmax = sec_gw.x_exciting_freqgrid.x_exciting_freqmax
         freqmin = sec_gw.x_exciting_freqgrid.x_exciting_freqmin
         values = [freqmin + i * (freqmax - freqmin) / n_freqs for i in range(n_freqs)] * ureg.hartree
         smearing = sec_gw.x_exciting_freqgrid.x_exciting_eta if sec_gw.x_exciting_qdepw == 'sum' else None
-        sec_freq_mesh = FreqMesh(
+        sec_freq_mesh = FrequencyMesh(
             type=sec_gw.x_exciting_freqgrid.x_exciting_fgrid,
             n_points=n_freqs,
             values=values,

--- a/electronicparsers/exciting/parser.py
+++ b/electronicparsers/exciting/parser.py
@@ -1800,9 +1800,7 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
         n_freqs = sec_run.method[-1].get('x_exciting_xs_energywindow_points')
         freqs = sec_run.method[-1].get('x_exciting_xs_energywindow_values')
         values = [freqs[0] + i * (freqs[-1] - freqs[0]) / n_freqs for i in range(n_freqs)]
-        sec_freq_mesh = FreqMesh(
-            n_points=n_freqs,
-            values=values)
+        sec_freq_mesh = FreqMesh(n_points=n_freqs, values=values)
         sec_bse.m_add_sub_section(BSE.frequency_mesh, sec_freq_mesh)
         # Screening
         sec_screening = Screening(

--- a/electronicparsers/exciting/parser.py
+++ b/electronicparsers/exciting/parser.py
@@ -1811,10 +1811,10 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
 
         # CoreHole
         if sec_run.method[-1].get('x_exciting_xs_bse_xas'):
-            sec_core = CoreHole(
+            sec_core_hole = CoreHole(
                 mode='absorption',
                 broadening=sec_run.method[-1].get('x_exciting_xs_broadening') * ureg.hartree)
-            sec_bse.m_add_sub_section(BSE.core, sec_core)
+            sec_bse.m_add_sub_section(BSE.core_hole, sec_core_hole)
             # TODO wait for new changes in metainfo for CoreHole
             # sec_core.edge = sec_run.method[0].get('x_exciting_xs_bse_xasedge')
 

--- a/electronicparsers/exciting/parser.py
+++ b/electronicparsers/exciting/parser.py
@@ -25,7 +25,7 @@ from nomad.units import ureg
 from nomad.parsing.file_parser import TextParser, Quantity, XMLParser, DataTextParser
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
-    Method, DFT, Electronic, Smearing, XCFunctional, Functional,Scf, BasisSet, KMesh,
+    Method, DFT, Electronic, Smearing, XCFunctional, Functional, Scf, BasisSet, KMesh,
     FreqMesh, Screening, GW, Photon, BSE, CoreHole
 )
 from nomad.datamodel.metainfo.simulation.system import (

--- a/electronicparsers/exciting/parser.py
+++ b/electronicparsers/exciting/parser.py
@@ -1787,33 +1787,33 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
 
         # BSE
         sec_bse = sec_method.m_create(BSE)
-        sec_bse.type = sec_run.method[-1].get('x_exciting_xs_bse_type')
-        sec_bse.n_empty_states = sec_run.method[-1].get('x_exciting_xs_number_of_empty_states')
-        sec_bse.broadening = sec_run.method[-1].get('x_exciting_xs_broadening') * ureg.hartree
+        sec_bse.type = sec_run.method[-1].x_exciting_xs_bse_type
+        sec_bse.n_empty_states = sec_run.method[-1].x_exciting_xs_number_of_empty_states
+        sec_bse.broadening = sec_run.method[-1].x_exciting_xs_broadening * ureg.hartree
         # KMesh
         sec_k_mesh = sec_method.m_create(KMesh)
-        sec_k_mesh.grid = sec_run.method[-1].get('x_exciting_xs_ngridk')
+        sec_k_mesh.grid = sec_run.method[-1].x_exciting_xs_ngridk
         # QMesh
-        sec_q_mesh = KMesh(grid=sec_run.method[-1].get('x_exciting_xs_ngridq'))
+        sec_q_mesh = KMesh(grid=sec_run.method[-1].x_exciting_xs_ngridq)
         sec_bse.m_add_sub_section(BSE.q_mesh, sec_q_mesh)
         # FrequencyMesh
-        n_freqs = sec_run.method[-1].get('x_exciting_xs_energywindow_points')
-        freqs = sec_run.method[-1].get('x_exciting_xs_energywindow_values')
+        n_freqs = sec_run.method[-1].x_exciting_xs_energywindow_points
+        freqs = sec_run.method[-1].x_exciting_xs_energywindow_values
         values = [freqs[0] + i * (freqs[-1] - freqs[0]) / n_freqs for i in range(n_freqs)]
         sec_freq_mesh = FrequencyMesh(n_points=n_freqs, values=values)
         sec_bse.m_add_sub_section(BSE.frequency_mesh, sec_freq_mesh)
         # Screening
         sec_screening = Screening(
-            type=sec_run.method[-1].get('x_exciting_xs_screening_type'),
-            n_empty_states=sec_run.method[-1].get('x_exciting_xs_screening_number_of_empty_states'))
-        sec_k_mesh_screening = KMesh(grid=sec_run.method[-1].get('x_exciting_xs_screening_ngridk'))
+            type=sec_run.method[-1].x_exciting_xs_screening_type,
+            n_empty_states=sec_run.method[-1].x_exciting_xs_screening_number_of_empty_states)
+        sec_k_mesh_screening = KMesh(grid=sec_run.method[-1].x_exciting_xs_screening_ngridk)
         sec_screening.m_add_sub_section(Screening.k_mesh, sec_k_mesh_screening)
 
         # CoreHole
-        if sec_run.method[-1].get('x_exciting_xs_bse_xas'):
+        if sec_run.method[-1].x_exciting_xs_bse_xas:
             sec_core_hole = CoreHole(
                 mode='absorption',
-                broadening=sec_run.method[-1].get('x_exciting_xs_broadening') * ureg.hartree)
+                broadening=sec_run.method[-1].x_exciting_xs_broadening * ureg.hartree)
             sec_bse.m_add_sub_section(BSE.core_hole, sec_core_hole)
             # TODO wait for new changes in metainfo for CoreHole
             # sec_core.edge = sec_run.method[0].get('x_exciting_xs_bse_xasedge')

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -27,7 +27,7 @@ from nomad.parsing.file_parser import TextParser, Quantity, DataTextParser
 from nomad.datamodel.metainfo.simulation.run import Run, Program, TimeRun
 from nomad.datamodel.metainfo.simulation.method import (
     Electronic, Method, XCFunctional, Functional, HubbardKanamoriModel, AtomParameters, DFT,
-    BasisSet, GW as GWMethod, KMesh, FreqMesh
+    BasisSet, GW, KMesh, FreqMesh
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
@@ -857,24 +857,29 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
 
         # GW method
         sec_method = sec_run.m_create(Method)
-        sec_gw = sec_method.m_create(GWMethod)
-        # Type
+        # GW
+        sec_gw = sec_method.m_create(GW)
         sec_gw.type = self._gw_flag_map.get(self.out_parser.get('gw_flag'), None)
-        # Q mesh
-        sec_k_mesh = sec_gw.m_create(KMesh)
+        sec_gw.n_states = self.out_parser.get('n_states_gw')
+        # KMesh
+        sec_k_mesh = sec_method.m_create(KMesh)
         sec_k_mesh.grid = self.out_parser.get('k_grid', [1, 1, 1])
+        # QMesh copied from KMesh
+        sec_gw.m_add_sub_section(GW.q_mesh, sec_k_mesh)
         # Analytical continuation
         sec_gw.analytical_continuation = self.gw_analytical_continuation[
             self.out_parser.get('anacon_type', 1)]
-        # Frequency grid
-        sec_freq_grid = sec_gw.m_create(FreqMesh)
-        sec_freq_grid.type = self.out_parser.get('freq_grid_type')
-        sec_freq_grid.n_points = self.out_parser.get('n_freq', 100)
+        # FreqMesh
         frequency_data = self.out_parser.get('frequency_data', None)
-        if frequency_data is not None:
-            sec_freq_grid.values = np.array(frequency_data)[:, 1] * ureg.hartree
-        # Other parameters
-        sec_gw.n_states_self_energy = self.out_parser.get('n_states_gw')
+        if frequency_data:
+            values = np.array(frequency_data)[:, 1] * ureg.hartree
+        else:
+            values = None
+        sec_freq_mesh = FreqMesh(
+            type=self.out_parser.get('freq_grid_type'),
+            n_points=self.out_parser.get('n_freq', 100),
+            values=values)
+        sec_gw.m_add_sub_section(GW.frequency_mesh, sec_freq_mesh)
 
         # GW calculation
         sec_scc = sec_run.m_create(Calculation)

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -870,8 +870,8 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
         sec_gw.analytical_continuation = self.gw_analytical_continuation[
             self.out_parser.get('anacon_type', 1)]
         # FrequencyMesh
-        frequency_data = self.out_parser.get('frequency_data', None)
-        if frequency_data:
+        frequency_data = self.out_parser.get('frequency_data', [])
+        if len(frequency_data) > 0:
             values = np.array(frequency_data)[:, 1] * ureg.hartree
         else:
             values = None

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -27,7 +27,7 @@ from nomad.parsing.file_parser import TextParser, Quantity, DataTextParser
 from nomad.datamodel.metainfo.simulation.run import Run, Program, TimeRun
 from nomad.datamodel.metainfo.simulation.method import (
     Electronic, Method, XCFunctional, Functional, HubbardKanamoriModel, AtomParameters, DFT,
-    BasisSet, GW, KMesh, FreqMesh
+    BasisSet, GW, KMesh, FrequencyMesh
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
@@ -869,13 +869,13 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
         # Analytical continuation
         sec_gw.analytical_continuation = self.gw_analytical_continuation[
             self.out_parser.get('anacon_type', 1)]
-        # FreqMesh
+        # FrequencyMesh
         frequency_data = self.out_parser.get('frequency_data', None)
         if frequency_data:
             values = np.array(frequency_data)[:, 1] * ureg.hartree
         else:
             values = None
-        sec_freq_mesh = FreqMesh(
+        sec_freq_mesh = FrequencyMesh(
             type=self.out_parser.get('freq_grid_type'),
             n_points=self.out_parser.get('n_freq', 100),
             values=values)

--- a/electronicparsers/ocean/parser.py
+++ b/electronicparsers/ocean/parser.py
@@ -120,7 +120,7 @@ class OceanParser(BeyondDFTWorkflowsParser):
         # BSE
         sec_bse = sec_method.m_create(BSE)
         bse_data = self.data.get('bse', {})
-        sec_bse.type = bse_data.get('val', {}).get('solver')
+        sec_bse.type = self._type_bse_map[bse_data.get('val', {}).get('solver')]
         sec_bse.n_states = bse_data.get('nbands', 1)
         # KMesh for BSE
         sec_k_mesh = KMesh(grid=bse_data.get('kmesh', []))
@@ -143,11 +143,11 @@ class OceanParser(BeyondDFTWorkflowsParser):
         if bse_core_data:
             sec_core = CoreHole(
                 mode=self.mode_bse[bse_core_data.get('strength')],
-                solver=self._type_bse_map[bse_core_data.get('solver')])
+                solver=self._type_bse_map[bse_core_data.get('solver')],
+                broadening=bse_core_data.get('broaden'))
             sec_bse.m_add_sub_section(BSE.core, sec_core)
             # TODO wait for new changes in metainfo for CoreHole
             # sec_core.edge = self._core_level_map[str(edges[0][-2:])]
-            # sec_core.broadening = self.data['bse']['core'].get('broaden')
 
         # code-specific parameters
         try:

--- a/electronicparsers/ocean/parser.py
+++ b/electronicparsers/ocean/parser.py
@@ -142,11 +142,11 @@ class OceanParser(BeyondDFTWorkflowsParser):
         # Core-Hole (either K=1s or L23=2p depenging on the first edge found)
         bse_core_data = bse_data.get('core')
         if bse_core_data:
-            sec_core = CoreHole(
+            sec_core_hole = CoreHole(
                 mode=self.mode_bse[bse_core_data.get('strength')],
                 solver=self._type_bse_map[bse_core_data.get('solver')],
                 broadening=bse_core_data.get('broaden') * ureg.eV)
-            sec_bse.m_add_sub_section(BSE.core, sec_core)
+            sec_bse.m_add_sub_section(BSE.core_hole, sec_core_hole)
             # TODO wait for new changes in metainfo for CoreHole
             # sec_core.edge = self._core_level_map[str(edges[0][-2:])]
 

--- a/electronicparsers/ocean/parser.py
+++ b/electronicparsers/ocean/parser.py
@@ -151,42 +151,39 @@ class OceanParser(BeyondDFTWorkflowsParser):
             # sec_core.edge = self._core_level_map[str(edges[0][-2:])]
 
         # code-specific parameters
-        try:
-            # BSE
-            sec_bse_ocean = sec_method.m_create(x_ocean_bse_parameters)
-            sec_bse_ocean.x_ocean_screen_radius = bse_core_data.get('screen_radius')
-            sec_bse_ocean.x_ocean_xmesh = bse_data.get('xmesh')
-            # screening
-            sec_bse_screen = sec_method.m_create(x_ocean_screen_parameters)
-            screen_keys = [
-                'all_augment', 'augment', 'convertstyle', 'dft_energy_range', 'inversionstyle',
-                'kshift', 'mimic_exciting_bands', 'shells']
-            screen_dicts = [
-                'core_offset', 'final', 'grid']
-            for key in screen_keys:
-                setattr(sec_bse_screen, f'x_ocean_{key}', screen_data.get(key))
-            for keys in screen_dicts:
-                for subkeys in screen_data[keys].keys():
-                    setattr(sec_bse_screen, f'x_ocean_{keys}_{subkeys}', screen_data[keys].get(subkeys))
-            sec_bse_screen.x_ocean_model_flavor = screen_data['model'].get('flavor')
-            # edges
-            edges = []
-            for ed in [x.split(' ') for x in self.data['calc'].get('edges', [])]:
-                edges.append([int(x) for x in ed])
-            sec_method.x_ocean_edges = edges
-            # core
-            if bse_core_data.get('solver') == 'haydock':
-                sec_haydock = sec_bse_ocean.m_create(x_ocean_core_haydock_parameters)
-                sec_haydock.x_ocean_converge_spacing = bse_core_data['haydock']['converge'].get('spacing')
-                sec_haydock.x_ocean_converge_thresh = bse_core_data['haydock']['converge'].get('thresh')
-                sec_haydock.x_ocean_niter = bse_core_data['haydock'].get('niter')
-            elif bse_core_data.get('solver') == 'gmres':
-                sec_gmres = sec_bse_ocean.m_create(x_ocean_core_gmres_parameters)
-                gmres_keys = ['echamp', 'elist', 'erange', 'estyle', 'ffff', 'gprc', 'nloop']
-                for key in gmres_keys:
-                    setattr(sec_gmres, f'x_ocean_{key}', bse_core_data['gmres'].get(key))
-        except Exception:
-            self.logger.warning('Error extracting code-specific quantities.')
+        # BSE
+        sec_bse_ocean = sec_method.m_create(x_ocean_bse_parameters)
+        sec_bse_ocean.x_ocean_screen_radius = bse_core_data.get('screen_radius')
+        sec_bse_ocean.x_ocean_xmesh = bse_data.get('xmesh')
+        # screening
+        sec_bse_screen = sec_method.m_create(x_ocean_screen_parameters)
+        screen_keys = [
+            'all_augment', 'augment', 'convertstyle', 'dft_energy_range', 'inversionstyle',
+            'kshift', 'mimic_exciting_bands', 'shells']
+        screen_dicts = [
+            'core_offset', 'final', 'grid']
+        for key in screen_keys:
+            setattr(sec_bse_screen, f'x_ocean_{key}', screen_data.get(key))
+        for keys in screen_dicts:
+            for subkeys in screen_data[keys].keys():
+                setattr(sec_bse_screen, f'x_ocean_{keys}_{subkeys}', screen_data[keys].get(subkeys))
+        sec_bse_screen.x_ocean_model_flavor = screen_data['model'].get('flavor')
+        # edges
+        edges = []
+        for ed in [x.split(' ') for x in self.data['calc'].get('edges', [])]:
+            edges.append([int(x) for x in ed])
+        sec_method.x_ocean_edges = edges
+        # core
+        if bse_core_data.get('solver') == 'haydock':
+            sec_haydock = sec_bse_ocean.m_create(x_ocean_core_haydock_parameters)
+            sec_haydock.x_ocean_converge_spacing = bse_core_data['haydock']['converge'].get('spacing')
+            sec_haydock.x_ocean_converge_thresh = bse_core_data['haydock']['converge'].get('thresh')
+            sec_haydock.x_ocean_niter = bse_core_data['haydock'].get('niter')
+        elif bse_core_data.get('solver') == 'gmres':
+            sec_gmres = sec_bse_ocean.m_create(x_ocean_core_gmres_parameters)
+            gmres_keys = ['echamp', 'elist', 'erange', 'estyle', 'ffff', 'gprc', 'nloop']
+            for key in gmres_keys:
+                setattr(sec_gmres, f'x_ocean_{key}', bse_core_data['gmres'].get(key))
 
     def parse_scc(self, path):
         sec_run = self._child_archives.get(path).run[-1]

--- a/electronicparsers/ocean/parser.py
+++ b/electronicparsers/ocean/parser.py
@@ -145,7 +145,7 @@ class OceanParser(BeyondDFTWorkflowsParser):
             sec_core = CoreHole(
                 mode=self.mode_bse[bse_core_data.get('strength')],
                 solver=self._type_bse_map[bse_core_data.get('solver')],
-                broadening=bse_core_data.get('broaden'))
+                broadening=bse_core_data.get('broaden') * ureg.eV)
             sec_bse.m_add_sub_section(BSE.core, sec_core)
             # TODO wait for new changes in metainfo for CoreHole
             # sec_core.edge = self._core_level_map[str(edges[0][-2:])]

--- a/electronicparsers/ocean/parser.py
+++ b/electronicparsers/ocean/parser.py
@@ -123,9 +123,9 @@ class OceanParser(BeyondDFTWorkflowsParser):
         sec_bse.type = self._type_bse_map[bse_data.get('val', {}).get('solver')]
         sec_bse.n_states = bse_data.get('nbands', 1)
         sec_bse.broadening = bse_data.get('val', {}).get('broaden') * ureg.eV
-        # KMesh for BSE
+        # KMesh
         sec_k_mesh = KMesh(grid=bse_data.get('kmesh', []))
-        sec_bse.m_add_sub_section(BSE.k_mesh, sec_k_mesh)
+        sec_method.m_add_sub_section(Method.k_mesh, sec_k_mesh)
         # QMesh copied from KMesh
         sec_bse.m_add_sub_section(BSE.q_mesh, sec_k_mesh)
         # Screening

--- a/electronicparsers/ocean/parser.py
+++ b/electronicparsers/ocean/parser.py
@@ -122,7 +122,7 @@ class OceanParser(BeyondDFTWorkflowsParser):
         bse_data = self.data.get('bse', {})
         sec_bse.type = self._type_bse_map[bse_data.get('val', {}).get('solver')]
         sec_bse.n_states = bse_data.get('nbands', 1)
-        sec_bse.broadening = bse_data.get('val', {}).get('broaden') * ureg.eV
+        sec_bse.broadening = bse_data.get('val', {}).get('broaden', 0.1) * ureg.eV
         # KMesh
         sec_k_mesh = sec_method.m_create(KMesh)
         sec_k_mesh.grid = bse_data.get('kmesh', [])
@@ -145,7 +145,7 @@ class OceanParser(BeyondDFTWorkflowsParser):
             sec_core_hole = CoreHole(
                 mode=self.mode_bse[bse_core_data.get('strength')],
                 solver=self._type_bse_map[bse_core_data.get('solver')],
-                broadening=bse_core_data.get('broaden') * ureg.eV)
+                broadening=bse_core_data.get('broaden', 0.1) * ureg.eV)
             sec_bse.m_add_sub_section(BSE.core_hole, sec_core_hole)
             # TODO wait for new changes in metainfo for CoreHole
             # sec_core.edge = self._core_level_map[str(edges[0][-2:])]

--- a/electronicparsers/ocean/parser.py
+++ b/electronicparsers/ocean/parser.py
@@ -27,7 +27,7 @@ from nomad.parsing.file_parser import DataTextParser, TextParser, Quantity
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.system import System, Atoms
 from nomad.datamodel.metainfo.simulation.method import (
-    Method, KMesh, Photon, CoreHole, ExcitedStateMethodology, Screening, BSE
+    Method, KMesh, Photon, CoreHole, Screening, BSE
 )
 from nomad.datamodel.metainfo.simulation.calculation import Calculation, Spectra
 from nomad.datamodel.metainfo.simulation.workflow import SinglePoint

--- a/electronicparsers/ocean/parser.py
+++ b/electronicparsers/ocean/parser.py
@@ -164,9 +164,9 @@ class OceanParser(BeyondDFTWorkflowsParser):
             'core_offset', 'final', 'grid']
         for key in screen_keys:
             setattr(sec_bse_screen, f'x_ocean_{key}', screen_data.get(key))
-        for keys in screen_dicts:
-            for subkeys in screen_data[keys].keys():
-                setattr(sec_bse_screen, f'x_ocean_{keys}_{subkeys}', screen_data[keys].get(subkeys))
+        for key in screen_dicts:
+            for subkey in screen_data[key].keys():
+                setattr(sec_bse_screen, f'x_ocean_{key}_{subkey}', screen_data[key].get(subkey))
         sec_bse_screen.x_ocean_model_flavor = screen_data['model'].get('flavor')
         # edges
         edges = []

--- a/electronicparsers/ocean/parser.py
+++ b/electronicparsers/ocean/parser.py
@@ -122,6 +122,7 @@ class OceanParser(BeyondDFTWorkflowsParser):
         bse_data = self.data.get('bse', {})
         sec_bse.type = self._type_bse_map[bse_data.get('val', {}).get('solver')]
         sec_bse.n_states = bse_data.get('nbands', 1)
+        sec_bse.broadening = bse_data.get('val', {}).get('broaden') * ureg.eV
         # KMesh for BSE
         sec_k_mesh = KMesh(grid=bse_data.get('kmesh', []))
         sec_bse.m_add_sub_section(BSE.k_mesh, sec_k_mesh)

--- a/electronicparsers/utils/utils.py
+++ b/electronicparsers/utils/utils.py
@@ -142,9 +142,6 @@ class BeyondDFTWorkflowsParser:
         input_structure = extract_section(self.archive, 'run/system')
         dft_calculation = extract_section(self.archive, 'run/calculation')
         gw_calculation = extract_section(gw_archive, 'run/calculation')
-        # workflow.m_add_sub_section(
-            # GW.inputs,
-            # Link(name='GW workflow parameters', section=workflow.method))
         if input_structure:
             workflow.m_add_sub_section(
                 GW.inputs, Link(name='Input structure', section=input_structure))

--- a/electronicparsers/utils/utils.py
+++ b/electronicparsers/utils/utils.py
@@ -23,9 +23,9 @@ from glob import glob
 from nomad.datamodel import EntryArchive
 from nomad.datamodel.metainfo.simulation.run import Run
 from nomad.datamodel.metainfo.workflow import Workflow, Task as Taskold, GW as GWold
-from nomad.datamodel.metainfo.workflow2 import Link, TaskReference, Task
+from nomad.datamodel.metainfo.workflow2 import Link, TaskReference
 from nomad.datamodel.metainfo.simulation.workflow import (
-    SinglePoint, GW, GWMethod, GWResults, ParticleHoleExcitations,
+    GW, GWMethod, GWResults, ParticleHoleExcitations,
     ParticleHoleExcitationsMethod, ParticleHoleExcitationsResults,
     PhotonPolarization, PhotonPolarizationMethod, PhotonPolarizationResults
 )

--- a/electronicparsers/utils/utils.py
+++ b/electronicparsers/utils/utils.py
@@ -31,7 +31,7 @@ from nomad.datamodel.metainfo.simulation.workflow import (
 )
 
 
-def extract_section(source, path):
+def extract_section(source: EntryArchive, path: str):
     '''
     Extracts the (last) section from source given by path. Examples:
         sec_system = extract_section(archive, 'run/system')
@@ -47,9 +47,11 @@ def extract_section(source, path):
     return source
 
 
-def get_files(pattern, filepath, stripname: str = '', deep: bool = True):
+def get_files(pattern: str, filepath: str, stripname: str = '', deep: bool = True):
     '''
-    Get files up to / down from the filepath (up ** or down ..).
+    Get files up to / down from the filepath (deep=`**` going up, and deep=`..` down,) to
+    find the file `pattern` with respect to the file `stripname` (normally being the
+    mainfile of the parser).
     '''
     for _ in range(10):
         filenames = glob(f'{os.path.dirname(filepath)}/{pattern}')
@@ -77,7 +79,11 @@ class BeyondDFTWorkflowsParser:
         self._child_archives = _child_archives
         self._xs_spectra_types = _xs_spectra_types
 
-    def run_workflow_archive(self, workflow_archive):
+    def run_workflow_archive(self, workflow_archive: EntryArchive):
+        '''
+        Initializes the workflow archive by checking if Run exists or not, as well as copying
+        Program and System into it.
+        '''
         if workflow_archive.run:
             sec_run = workflow_archive.run[-1]
         else:
@@ -85,7 +91,7 @@ class BeyondDFTWorkflowsParser:
         sec_run.program = self.archive.run[-1].program
         sec_run.system = self.archive.run[-1].system
 
-    def parse_gw_workflow(self, gw_archive, gw_workflow_archive):
+    def parse_gw_workflow(self, gw_archive: EntryArchive, gw_workflow_archive: EntryArchive):
         '''
             self.archive = DFT archive
             gw_archive = GW archive
@@ -222,7 +228,7 @@ class BeyondDFTWorkflowsParser:
 
         self.archive.workflow2 = workflow
 
-    def parse_xs_workflow(self, xs_archives, xs_workflow_archive):
+    def parse_xs_workflow(self, xs_archives: EntryArchive, xs_workflow_archive: EntryArchive):
         '''
             self.archive = DFT archive
             xs_archives = archives for all Spectra workflows

--- a/electronicparsers/utils/utils.py
+++ b/electronicparsers/utils/utils.py
@@ -27,7 +27,7 @@ from nomad.datamodel.metainfo.workflow2 import Link, TaskReference, Task
 from nomad.datamodel.metainfo.simulation.workflow import (
     SinglePoint, GW, GWMethod, GWResults, ParticleHoleExcitations,
     ParticleHoleExcitationsMethod, ParticleHoleExcitationsResults,
-    PhotonPolarization, PhotonPolarizationResults
+    PhotonPolarization, PhotonPolarizationMethod, PhotonPolarizationResults
 )
 
 
@@ -125,19 +125,19 @@ class BeyondDFTWorkflowsParser:
             method=GWMethod(),
             results=GWResults())
         workflow.name = 'GW'
-        # method
+        # Method
         method_gw = extract_section(gw_archive, 'run/method/gw')
         method_xcfunctional = extract_section(self.archive, 'run/method/dft/xc_functional')
         method_basisset = extract_section(self.archive, 'run/method/basis_set')
         workflow.method.gw_method_ref = method_gw
         workflow.method.starting_point = method_xcfunctional
         workflow.method.basis_set = method_basisset
-        # results
+        # Results
         workflow.results.dos_dft = dos_dft
         workflow.results.dos_gw = dos_gw
         workflow.results.band_structure_dft = bs_dft
         workflow.results.band_structure_gw = bs_gw
-        # inputs and outputs
+        # Inputs and Outputs
         input_structure = extract_section(self.archive, 'run/system')
         dft_calculation = extract_section(self.archive, 'run/calculation')
         gw_calculation = extract_section(gw_archive, 'run/calculation')
@@ -178,41 +178,50 @@ class BeyondDFTWorkflowsParser:
             self.archive = archive for the workflow
             self._child_archives = archives for SinglePoint photons
         '''
-        workflow = PhotonPolarization(results=PhotonPolarizationResults())
+        workflow = PhotonPolarization(
+            method=PhotonPolarizationMethod(),
+            results=PhotonPolarizationResults())
         workflow.name = 'Spectra'
-
+        # Method (TODO define Method)
+        # Inputs
         input_structure = self.archive.run[-1].system[-1]
+        workflow.m_add_sub_section(
+            PhotonPolarization.inputs,
+            Link(name='Input structure', section=input_structure))
         input_method = self.archive.run[-1].method[-1]
-        workflow.inputs = [
-            Link(name='Input structure', section=input_structure),
-            # TODO this should be put under PhotonPolarizationMethod e.g. as method_ref
-            Link(name='Input BSE methodology', section=input_method)]
+        workflow.m_add_sub_section(
+            PhotonPolarization.inputs,
+            Link(name='Input BSE methodology', section=input_method))
+        # Outputs
         spectra = []
-        outputs = []
         for path in self._child_archives.keys():
             archive = self._child_archives.get(path)
             index = list(self._child_archives.keys()).index(path)
-            archive.workflow2 = SinglePoint()
-            archive.workflow2.name = 'SinglePoint'
 
-            task = TaskReference(task=archive.workflow2)
-            input_photon_method = archive.run[-1].method[0]
-            if input_structure and input_photon_method:
-                archive.workflow2.inputs = [
-                    Link(name='Input structure', section=input_structure),
-                    Link(name='Input photon parameters', section=input_photon_method)]
-            output_calculation = archive.run[-1].calculation[-1]  # ref to EPSILON calculation
-            if output_calculation:
-                archive.workflow2.outputs = [Link(name=f'Output polarization {index + 1}', section=output_calculation)]
-                spectra.append(output_calculation.spectra[0])
-                outputs.append(Link(name=f'Output polarization {index + 1}', section=output_calculation))
-            archive.workflow2.tasks = [Task(inputs=archive.workflow2.inputs, outputs=archive.workflow2.outputs)]
-            workflow.tasks.append(task)
+            output_polarization = archive.run[-1].calculation[-1]
+            if output_polarization:
+                workflow.m_add_sub_section(
+                    PhotonPolarization.outputs,
+                    Link(name=f'Output polarization {index + 1}', section=output_polarization))
+                spectra.append(output_polarization.spectra[0])
 
+            # Tasks
+            if archive.workflow2:
+                task = TaskReference(task=archive.workflow2)
+                task.name = f'Photon {index + 1}'
+                input_photon_method = archive.run[-1].method[0]
+                if input_photon_method and input_structure:
+                    task.inputs = [
+                        Link(name='Input structure', section=input_structure),
+                        Link(name='Input photon parameters', section=input_photon_method)]
+                if output_polarization:
+                    task.outputs = [
+                        Link(name=f'Output polarization {index + 1}', section=output_polarization)]
+                workflow.m_add_sub_section(PhotonPolarization.tasks, task)
+        # Results
         workflow.results.n_polarizations = len(spectra)
         workflow.results.spectrum_polarization = spectra
-        outputs.append(Link(name='Workflow results', section=workflow.results))
-        workflow.outputs = outputs
+
         self.archive.workflow2 = workflow
 
     def parse_xs_workflow(self, xs_archives, xs_workflow_archive):

--- a/electronicparsers/utils/utils.py
+++ b/electronicparsers/utils/utils.py
@@ -192,9 +192,8 @@ class BeyondDFTWorkflowsParser:
 
         # Outputs
         spectra = []
-        for path in self._child_archives.keys():
+        for index, path in enumerate(self._child_archives.keys()):
             archive = self._child_archives.get(path)
-            index = list(self._child_archives.keys()).index(path)
 
             output_polarization = extract_section(archive, 'run/calculation')
             if output_polarization:
@@ -264,8 +263,7 @@ class BeyondDFTWorkflowsParser:
         if input_structure:
             workflow.m_add_sub_section(
                 ParticleHoleExcitations.inputs, Link(name='Input structure', section=input_structure))
-        for polarizations in polarization_calculations:
-            index = polarization_calculations.index(polarizations)
+        for index, polarizations in enumerate(polarization_calculations):
             workflow.m_add_sub_section(
                 ParticleHoleExcitations.outputs, Link(name=f'Polarization {index + 1}', section=polarizations))
 
@@ -280,17 +278,17 @@ class BeyondDFTWorkflowsParser:
             workflow.m_add_sub_section(ParticleHoleExcitations.tasks, task)
 
         # Spectra task
-        for xs_archive in xs_archives:
-            if xs_archive.workflow2:
-                index = list(xs_archives).index(xs_archive)
-                task = TaskReference(task=xs_archive.workflow2)
-                task.name = f'Spectra {index + 1}'
-                if dft_calculation:
-                    xs_archive.workflow2.m_add_sub_section(
-                        PhotonPolarization.inputs, Link(name='Output DFT calculation', section=dft_calculation))
-                    for photon_task in xs_archive.workflow2.tasks:
-                        photon_task.m_add_sub_section(
-                            TaskReference.inputs, Link(name='Output DFT calculation', section=dft_calculation))
-                workflow.m_add_sub_section(ParticleHoleExcitations.tasks, task)
+        for index, xs_archive in enumerate(xs_archives):
+            if not xs_archive.workflow2:
+                continue
+            task = TaskReference(task=xs_archive.workflow2)
+            task.name = f'Spectra {index + 1}'
+            if dft_calculation:
+                xs_archive.workflow2.m_add_sub_section(
+                    PhotonPolarization.inputs, Link(name='Output DFT calculation', section=dft_calculation))
+                for photon_task in xs_archive.workflow2.tasks:
+                    photon_task.m_add_sub_section(
+                        TaskReference.inputs, Link(name='Output DFT calculation', section=dft_calculation))
+            workflow.m_add_sub_section(ParticleHoleExcitations.tasks, task)
 
         xs_workflow_archive.workflow2 = workflow

--- a/electronicparsers/utils/utils.py
+++ b/electronicparsers/utils/utils.py
@@ -121,7 +121,9 @@ class BeyondDFTWorkflowsParser:
         gw_old.band_structure_gw = bs_gw
 
         # New workflow
-        workflow = GW(method=GWMethod(), results=GWResults())
+        workflow = GW(
+            method=GWMethod(),
+            results=GWResults())
         workflow.name = 'GW'
         # method
         method_gw = extract_section(gw_archive, 'run/method/gw')
@@ -139,27 +141,35 @@ class BeyondDFTWorkflowsParser:
         input_structure = extract_section(self.archive, 'run/system')
         dft_calculation = extract_section(self.archive, 'run/calculation')
         gw_calculation = extract_section(gw_archive, 'run/calculation')
-        workflow.inputs.append(Link(name='Workflow parameters', section=workflow.method))
+        workflow.m_add_sub_section(
+            GW.inputs,
+            Link(name='GW workflow parameters', section=workflow.method))
         if input_structure:
-            workflow.inputs.append(Link(name='Input structure', section=input_structure))
+            workflow.m_add_sub_section(
+                GW.inputs,
+                Link(name='Input structure', section=input_structure))
         if gw_calculation:
-            workflow.outputs.append(Link(name='Output GW calculation', section=gw_calculation))
+            workflow.m_add_sub_section(
+                GW.outputs,
+                Link(name='Output GW calculation', section=gw_calculation))
         # DFT task
         if self.archive.workflow2:
             task = TaskReference(task=self.archive.workflow2)
+            task.name = 'DFT'
             if input_structure:
                 task.inputs = [Link(name='Input structure', section=input_structure)]
             if dft_calculation:
                 task.outputs = [Link(name='Output DFT calculation', section=dft_calculation)]
-            workflow.tasks.append(task)
+            workflow.m_add_sub_section(GW.tasks, task)
         # GW task
         if gw_archive.workflow2:
             task = TaskReference(task=gw_archive.workflow2)
+            task.name = 'GW'
             if dft_calculation:
                 task.inputs = [Link(name='Input DFT calculation', section=dft_calculation)]
             if gw_calculation:
                 task.outputs = [Link(name='Output GW calculation', section=gw_calculation)]
-            workflow.tasks.append(task)
+            workflow.m_add_sub_section(GW.tasks, task)
 
         gw_workflow_archive.workflow2 = workflow
 

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -44,7 +44,7 @@ from nomad.parsing.file_parser.text_parser import TextParser, Quantity
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
     Method, BasisSet, BasisSetCellDependent, DFT, HubbardKanamoriModel, AtomParameters,
-    XCFunctional, Functional, Electronic, Scf, KMesh, GW, FreqMesh
+    XCFunctional, Functional, Electronic, Scf, KMesh, GW, FrequencyMesh
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
@@ -1368,8 +1368,8 @@ class VASPParser():
         sec_gw.m_add_sub_section(GW.q_mesh, sec_method.k_mesh)
         # Analytical continuation
         sec_gw.analytical_continuation = 'pade'
-        # FreqMesh
-        sec_freq_mesh = FreqMesh(n_points=response_functions.get('NOMEGA', 100))
+        # FrequencyMesh
+        sec_freq_mesh = FrequencyMesh(n_points=response_functions.get('NOMEGA', 100))
         sec_gw.m_add_sub_section(GW.frequency_mesh, sec_freq_mesh)
 
     def parse_workflow(self):

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -1370,7 +1370,7 @@ class VASPParser():
         sec_gw.analytical_continuation = 'pade'
         # FreqMesh
         sec_freq_mesh = FreqMesh(
-            n_points = response_functions.get('NOMEGA', 100))
+            n_points=response_functions.get('NOMEGA', 100))
         sec_gw.m_add_sub_section(GW.frequency_mesh, sec_freq_mesh)
 
     def parse_workflow(self):

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -1369,8 +1369,7 @@ class VASPParser():
         # Analytical continuation
         sec_gw.analytical_continuation = 'pade'
         # FreqMesh
-        sec_freq_mesh = FreqMesh(
-            n_points=response_functions.get('NOMEGA', 100))
+        sec_freq_mesh = FreqMesh(n_points=response_functions.get('NOMEGA', 100))
         sec_gw.m_add_sub_section(GW.frequency_mesh, sec_freq_mesh)
 
     def parse_workflow(self):

--- a/tests/test_abinitparser.py
+++ b/tests/test_abinitparser.py
@@ -114,15 +114,25 @@ def test_gw(parser):
     parser.parse('tests/data/abinit/ZrO2_GW/A1.abo', archive, None)
 
     sec_run = archive.run[-1]
-    sec_gw = sec_run.method[-1].gw
+
+    # Method
+    sec_method = sec_run.method
+    assert len(sec_method) == 1
+    assert sec_method[-1].m_xpath('gw') and sec_method[-1].m_xpath('k_mesh')
+    assert sec_method[-1].k_mesh.n_points == 3
+    sec_gw = sec_method[-1].gw
     assert sec_gw.type == 'G0W0'
     assert sec_gw.analytical_continuation == 'contour_deformation'
     assert sec_gw.interval_qp_corrections[0] == 12
     assert sec_gw.interval_qp_corrections[-1] == 13
-    assert sec_gw.n_states_self_energy == 512
-    assert sec_gw.n_empty_states_self_energy == approx(sec_gw.n_empty_states_polarizability)
-    assert sec_gw.frequency_grid.n_points == 2
-    assert sec_gw.frequency_grid.values[-1].to('eV').magnitude == approx(31.855950000000004j)
+    assert sec_gw.n_states == 512
+    assert sec_gw.n_empty_states == 500
+    assert sec_gw.screening.n_empty_states == sec_gw.n_empty_states
+    assert sec_gw.frequency_mesh.n_points == 2
+    assert sec_gw.frequency_mesh.values[-1].to('eV').magnitude == approx(31.855950000000004j)
+    assert sec_gw.q_mesh.n_points == sec_method[-1].k_mesh.n_points
+
+    # Calculation
     sec_scc = sec_run.calculation
     assert len(sec_scc) == 1
     assert sec_scc[-1].m_xpath('x_abinit_screening')

--- a/tests/test_excitingparser.py
+++ b/tests/test_excitingparser.py
@@ -162,11 +162,14 @@ def test_gw(silicon_gw):
     assert sec_gw.x_exciting_barecoul.x_exciting_barcevtol == approx(0.1)
     assert sec_gw.type == 'G0W0'
     assert sec_gw.analytical_continuation == 'pade'
-    assert sec_gw.n_empty_states_polarizability == approx(sec_gw.n_empty_states_self_energy)
-    assert sec_gw.frequency_grid.type == 'gauleg2'
-    assert sec_gw.frequency_grid.n_points == 32
-    assert sec_gw.frequency_grid.values[4].to('hartree').magnitude == approx(0.125)
-    assert (sec_gw.q_grid.grid == np.array([2, 2, 2])).all()
+    assert sec_gw.n_empty_states == 100
+    assert sec_gw.screening.type == 'rpa'
+    assert sec_gw.screening.n_empty_states == sec_gw.n_empty_states
+    assert (sec_gw.screening.k_mesh.grid == np.array([2, 2, 2])).all()
+    assert sec_gw.frequency_mesh.type == 'gauleg2'
+    assert sec_gw.frequency_mesh.n_points == 32
+    assert sec_gw.frequency_mesh.values[4].to('hartree').magnitude == approx(0.125 + 0j)
+    assert (sec_gw.q_mesh.grid == np.array([2, 2, 2])).all()
 
     sec_sccs = silicon_gw.run[0].calculation
     assert len(sec_sccs) == 1

--- a/tests/test_oceanparser.py
+++ b/tests/test_oceanparser.py
@@ -37,7 +37,7 @@ def test_tio2(parser):
     archive = EntryArchive()
     parser.parse('tests/data/ocean/ms-10734/Spectra-1-1-1/postDefaultsOceanDatafile', archive, None)
 
-    sec_run = archive.run[0]
+    sec_run = archive.run[-1]
 
     # Method
     sec_method = sec_run.method
@@ -47,6 +47,7 @@ def test_tio2(parser):
     assert sec_bse.type == 'lanczos-haydock'
     assert sec_bse.n_states == 119
     assert sec_bse.broadening.to('eV').magnitude == approx(0.1)
+    assert (sec_bse.q_mesh.grid == np.array([1, 1, 1])).all()
     assert sec_bse.screening.type == 'core'
     assert sec_bse.screening.n_states == 472
     assert sec_bse.screening.dielectric_infinity == 1000000
@@ -54,7 +55,7 @@ def test_tio2(parser):
     assert (sec_method[-1].x_ocean_edges[0] == np.array([1, 1, 0])).all()
     assert sec_bse.core.solver == 'lanczos-haydock'
     assert sec_bse.core.mode == 'absorption'
-    assert sec_bse.core.broadening.magnitude == approx(0.89)
+    assert sec_bse.core.broadening.to('eV').magnitude == approx(0.89)
     sec_ocean_screen = sec_method[-1].x_ocean_screen
     assert sec_ocean_screen.m_mod_count == 22
     assert sec_ocean_screen.x_ocean_dft_energy_range == approx(150.0)

--- a/tests/test_oceanparser.py
+++ b/tests/test_oceanparser.py
@@ -46,6 +46,7 @@ def test_tio2(parser):
     sec_bse = sec_method[-1].bse
     assert sec_bse.type == 'lanczos-haydock'
     assert sec_bse.n_states == 119
+    assert sec_bse.broadening.to('eV').magnitude == approx(0.1)
     assert sec_bse.screening.type == 'core'
     assert sec_bse.screening.n_states == 472
     assert sec_bse.dielectric_infinity == 1000000

--- a/tests/test_oceanparser.py
+++ b/tests/test_oceanparser.py
@@ -53,9 +53,9 @@ def test_tio2(parser):
     assert sec_bse.screening.dielectric_infinity == 1000000
     assert (sec_bse.screening.k_mesh.grid == np.array([3, 3, 2])).all()
     assert (sec_method[-1].x_ocean_edges[0] == np.array([1, 1, 0])).all()
-    assert sec_bse.core.solver == 'lanczos-haydock'
-    assert sec_bse.core.mode == 'absorption'
-    assert sec_bse.core.broadening.to('eV').magnitude == approx(0.89)
+    assert sec_bse.core_hole.solver == 'lanczos-haydock'
+    assert sec_bse.core_hole.mode == 'absorption'
+    assert sec_bse.core_hole.broadening.to('eV').magnitude == approx(0.89)
     sec_ocean_screen = sec_method[-1].x_ocean_screen
     assert sec_ocean_screen.m_mod_count == 22
     assert sec_ocean_screen.x_ocean_dft_energy_range == approx(150.0)

--- a/tests/test_oceanparser.py
+++ b/tests/test_oceanparser.py
@@ -49,7 +49,7 @@ def test_tio2(parser):
     assert sec_bse.broadening.to('eV').magnitude == approx(0.1)
     assert sec_bse.screening.type == 'core'
     assert sec_bse.screening.n_states == 472
-    assert sec_bse.dielectric_infinity == 1000000
+    assert sec_bse.screening.dielectric_infinity == 1000000
     assert (sec_bse.screening.k_mesh.grid == np.array([3, 3, 2])).all()
     assert (sec_method[-1].x_ocean_edges[0] == np.array([1, 1, 0])).all()
     assert sec_bse.core.solver == 'lanczos-haydock'

--- a/tests/test_oceanparser.py
+++ b/tests/test_oceanparser.py
@@ -44,14 +44,14 @@ def test_tio2(parser):
     assert len(sec_method) == 1
     assert sec_method[-1].m_xpath('bse')
     sec_bse = sec_method[-1].bse
-    assert sec_bse.n_empty_states == 119
-    assert sec_bse.screening_type == 'core'
+    assert sec_bse.type == 'lanczos-haydock'
+    assert sec_bse.n_states == 119
+    assert sec_bse.screening.type == 'core'
+    assert sec_bse.screening.n_states == 472
     assert sec_bse.dielectric_infinity == 1000000
-    assert sec_bse.n_empty_states_screening == 472
-    assert (sec_bse.k_mesh_screening.grid == np.array([3, 3, 2])).all()
+    assert (sec_bse.screening.k_mesh.grid == np.array([3, 3, 2])).all()
     assert (sec_method[-1].x_ocean_edges[0] == np.array([1, 1, 0])).all()
     assert sec_bse.core.solver == 'lanczos-haydock'
-    assert sec_bse.core.edge == 'K'
     assert sec_bse.core.mode == 'absorption'
     assert sec_bse.core.broadening.magnitude == approx(0.89)
     sec_ocean_screen = sec_method[-1].x_ocean_screen

--- a/tests/test_vaspparser.py
+++ b/tests/test_vaspparser.py
@@ -326,12 +326,20 @@ def test_gw(silicon_gw):
     """
     sec_run = silicon_gw.run[-1]
     sec_method = sec_run.method[-1]
-    assert sec_method.m_xpath('gw')
+    assert sec_method.m_xpath('gw') and sec_method.m_xpath('k_mesh')
     assert not sec_method.m_xpath('dft')
+    assert (sec_method.k_mesh.grid == np.array([6, 6, 6])).all()
     assert sec_method.gw.type == 'G0W0'
     assert sec_method.gw.analytical_continuation == 'pade'
-    assert sec_method.gw.n_states_self_energy == 72
-    assert (sec_method.k_mesh.grid == np.array([6, 6, 6])).all()
-    assert (sec_method.gw.q_grid.grid == np.array([6, 6, 6])).all()
-    assert sec_method.gw.q_grid.generation_method == 'Gamma'
-    assert sec_method.gw.frequency_grid.n_points == 50
+    assert sec_method.gw.n_states == 72
+    assert (sec_method.gw.q_mesh.grid == np.array([6, 6, 6])).all()
+    assert sec_method.gw.q_mesh.generation_method == 'Gamma'
+    assert sec_method.gw.frequency_mesh.n_points == 50
+    sec_scc = sec_run.calculation
+    assert len(sec_scc) == 1
+    homo = sec_scc[-1].energy.highest_occupied.to('eV').magnitude
+    lumo = sec_scc[-1].energy.lowest_unoccupied.to('eV').magnitude
+    assert homo == approx(2.132)
+    assert lumo == approx(3.8526)
+    bandgap = lumo - homo
+    assert bandgap == approx(1.7206)


### PR DESCRIPTION
@ladinesa I worked a bit more on the GW and BSE parsing for all the electronic codes (OCEAN, exciting, FHIaims, VASP, ABINIT).

As you can maybe see in the corresponding nomad MR, now there is a base class called `ExcitedStateMethodology`. This contains the shared method parameters amongst `Screening`, `GW` and `BSE`. Each of these methods can contain extra quantities or sub-sections (e.g., `dielectric_infinity` quantity for `Screening`, or `core` subsection for `BSE`).

Please, also check the new syntax, as I think now it is a bit more clean. This also goes with the use of `m_add_sub_section`.

I will also:
- [x] Adapt and improve the testing to the new metainfo.
- [x] Adapt `utils.py` to use `m_` operations.