### PR TITLE
Fix on regex for reciprocal_cell_units

### DIFF
--- a/electronicparsers/quantumespresso/parser.py
+++ b/electronicparsers/quantumespresso/parser.py
@@ -1936,7 +1936,8 @@ class QuantumEspressoOutParser(TextParser):
                 dtype=float, shape=(3, 3)),
             Quantity(
                 'reciprocal_cell_units',
-                r'reciprocal axes: \(cart\. coord\. in units of ([\w ]+)\)\s*'),
+                r'reciprocal axes: \(cart\. coord\. in units ([\w \/]+)\)',
+                flatten=False),
             Quantity(
                 'reciprocal_cell',
                 r'b\(1\) = \(([\-\d\. ]+)\)\s*b\(2\) = \(([\-\d\. ]+)\)\s*b\(3\) = \(([\-\d\. ]+)\)\s*',


### PR DESCRIPTION
@ladinesa can you please check this fix? Not sure how to do the regex such that it greps '2 pi/alat' as a string instead of a list [2, 'pi/alat']. That's why I created this "dummy" method `list_to_single_str`.

Thanks!

Closes #75 