### PR TITLE
Update basis set

### DIFF
--- a/electronicparsers/abacus/metainfo/abacus.py
+++ b/electronicparsers/abacus/metainfo/abacus.py
@@ -161,12 +161,12 @@ class x_abacus_section_specie_basis_set(MSection):
         ''')
 
 
-class x_abacus_section_basis_sets(MSection):
+class BasisSet(simulation.method.BasisSet):
     '''
     section for numerical atomic orbitals of ABACUS
     '''
 
-    m_def = Section(validate=False)
+    m_def = Section(validate=False, extends_base_section=True)
 
     x_abacus_basis_sets_delta_k = Quantity(
         type=np.dtype(np.float64),
@@ -195,13 +195,6 @@ class x_abacus_section_basis_sets(MSection):
     x_abacus_basis_sets_rmax = Quantity(
         type=np.dtype(np.float64),
         unit='bohr',
-        shape=[],
-        description='''
-        -
-        ''')
-
-    x_abacus_basis_sets_kmesh = Quantity(
-        type=np.dtype(np.int32),
         shape=[],
         description='''
         -
@@ -550,10 +543,6 @@ class Method(simulation.method.Method):
         The size of basis of auxiliary basis functions is reduced using principal component analysis.
         ''',
         categories=[x_abacus_input_settings, x_abacus_exx_settings])
-
-    x_abacus_section_basis_sets = SubSection(
-        sub_section=SectionProxy('x_abacus_section_basis_sets'),
-        repeats=True,)
 
 
 class System(simulation.system.System):

--- a/electronicparsers/abacus/parser.py
+++ b/electronicparsers/abacus/parser.py
@@ -1495,7 +1495,7 @@ class ABACUSParser:
                 cutoff=header.get(f'{name}_cutoff'),  # http://abacus.deepmodeling.com/en/latest/advanced/input_files/input-main.html#ecutwfc
             )
             if orbital_settings:
-                bs.type = 'numerical AOs'
+                bs.type = 'numeric AOs'
                 for key in ['delta_k', 'delta_r', 'dr_uniform', 'rmax', 'kmesh']:
                     val = orbital_settings.get(key)
                     setattr(bs, f'x_abacus_basis_sets_{key}', val)

--- a/electronicparsers/abacus/parser.py
+++ b/electronicparsers/abacus/parser.py
@@ -1495,7 +1495,7 @@ class ABACUSParser:
                 cutoff=header.get(f'{name}_cutoff'),  # http://abacus.deepmodeling.com/en/latest/advanced/input_files/input-main.html#ecutwfc
             )
             if orbital_settings:
-                bs.type = 'numerical atomic orbitals'
+                bs.type = 'numerical AOs'
                 for key in ['delta_k', 'delta_r', 'dr_uniform', 'rmax', 'kmesh']:
                     val = orbital_settings.get(key)
                     setattr(bs, f'x_abacus_basis_sets_{key}', val)

--- a/electronicparsers/abacus/parser.py
+++ b/electronicparsers/abacus/parser.py
@@ -29,7 +29,7 @@ from nomad.units import ureg
 from nomad.parsing.file_parser import TextParser, Quantity, DataTextParser
 from nomad.datamodel.metainfo.simulation.run import Run, Program, TimeRun
 from nomad.datamodel.metainfo.simulation.method import (
-    AtomParameters, Method, BasisSet, BasisSetCellDependent, Electronic, Smearing, Scf,
+    AtomParameters, Method, BasisSet, BasisSetContainer, Electronic, Smearing, Scf,
     DFT, XCFunctional, Functional, KMesh)
 from nomad.datamodel.metainfo.simulation.system import System, Atoms, Symmetry
 from nomad.datamodel.metainfo.simulation.calculation import (
@@ -40,7 +40,7 @@ from nomad.datamodel.metainfo.simulation.workflow import (
     GeometryOptimization as GeometryOptimization2, MolecularDynamics as MolecularDynamics2,
     MolecularDynamicsMethod, GeometryOptimizationMethod, SinglePoint as SinglePoint2, SinglePointMethod)
 from .metainfo.abacus import (
-    Method as xsection_method, x_abacus_section_parallel, x_abacus_section_basis_sets, x_abacus_section_specie_basis_set)
+    Method as xsection_method, x_abacus_section_parallel, x_abacus_section_specie_basis_set)
 
 
 # TODO determine if we can update regex to the following
@@ -1485,47 +1485,35 @@ class ABACUSParser:
         sec_method.x_abacus_basis_type = self.input_parser.get(
             'basis_type', 'pw')
 
-        # pw settings
+        # basis set settings
+        ems: list(BasisSetContainer) = []
         for name in ['wavefunction', 'density']:
-            cutoff = header.get(f'{name}_cutoff')
-            if cutoff is None:
-                continue
-            sec_method_basis_set = sec_method.m_create(BasisSet)
-            sec_method_basis_set.type = 'Numeric AOs' if header.get(
-                'orbital_settings') else 'plane waves'
-            sec_method_basis_set.kind = name
-            sec_basis_set = sec_method_basis_set.m_create(
-                BasisSetCellDependent)
-            sec_basis_set.planewave_cutoff = cutoff.to(
-                'joule').magnitude
-            sec_basis_set.kind = 'plane_waves'
-            sec_basis_set.name = 'PW_%.1f' % cutoff.magnitude
-            for key in ['pw', 'sticks']:
-                val = header.get(f'number_of_{key}_for_{name}')
-                setattr(
-                    sec_method, f'x_abacus_number_of_{key}_for_{name}', val)
-
-        # lcao settings
-        orbital_settings = header.get('orbital_settings')
-        if orbital_settings:
-            sec_basis_set = sec_method.m_create(x_abacus_section_basis_sets)
-            for key in ['delta_k', 'delta_r', 'dr_uniform', 'rmax', 'kmesh']:
-                val = orbital_settings.get(key)
-                setattr(sec_basis_set, f'x_abacus_basis_sets_{key}', val)
-
-            for i, orb in enumerate(orbital_settings.get('orbital_information', [])):
-                sec_specie_basis_set = sec_basis_set.m_create(
-                    x_abacus_section_specie_basis_set)
-                sec_specie_basis_set.x_abacus_specie_basis_set_filename = os.path.basename(
-                    header.get('orbital_files')[i])
-                ln_list = []
-                for data in orb:
-                    ln_list.append([data.l, data.n])
-                sec_specie_basis_set.x_abacus_specie_basis_set_ln = ln_list
-                sec_specie_basis_set.x_abacus_specie_basis_set_rcutoff = data.rcut
-                sec_specie_basis_set.x_abacus_specie_basis_set_rmesh = data.nr
-                sec_specie_basis_set.x_abacus_specie_basis_set_number_of_orbitals = len(
-                    ln_list)
+            orbital_settings = header.get('orbital_settings')
+            bs = BasisSet(
+                type='plane waves',
+                scope=['valence'],
+                cutoff=header.get(f'{name}_cutoff'),  # http://abacus.deepmodeling.com/en/latest/advanced/input_files/input-main.html#ecutwfc
+            )
+            if orbital_settings:
+                bs.type = 'numerical atomic orbitals'
+                for key in ['delta_k', 'delta_r', 'dr_uniform', 'rmax', 'kmesh']:
+                    val = orbital_settings.get(key)
+                    setattr(bs, f'x_abacus_basis_sets_{key}', val)
+                for i, orb in enumerate(orbital_settings.get('orbital_information', [])):
+                    sec_specie_basis_set = bs.m_create(
+                        x_abacus_section_specie_basis_set)
+                    sec_specie_basis_set.x_abacus_specie_basis_set_filename = os.path.basename(
+                        header.get('orbital_files')[i])
+                    ln_list = []
+                    for data in orb:
+                        ln_list.append([data.l, data.n])
+                    sec_specie_basis_set.x_abacus_specie_basis_set_ln = ln_list
+                    sec_specie_basis_set.x_abacus_specie_basis_set_rcutoff = data.rcut
+                    sec_specie_basis_set.x_abacus_specie_basis_set_rmesh = data.nr
+                    sec_specie_basis_set.x_abacus_specie_basis_set_number_of_orbitals = len(
+                        ln_list)
+            ems.append(BasisSetContainer(scope=[name], basis_set=[bs]))
+        sec_method.electronic_model = ems
 
         if self.input_parser.get('dft_plus_u'):
             sec_electronic.method = 'DFT+U'

--- a/electronicparsers/abacus/parser.py
+++ b/electronicparsers/abacus/parser.py
@@ -1513,7 +1513,7 @@ class ABACUSParser:
                     sec_specie_basis_set.x_abacus_specie_basis_set_number_of_orbitals = len(
                         ln_list)
             ems.append(BasisSetContainer(scope=[name], basis_set=[bs]))
-        sec_method.electronic_model = ems
+        sec_method.electrons_representation = ems
 
         if self.input_parser.get('dft_plus_u'):
             sec_electronic.method = 'DFT+U'

--- a/electronicparsers/abinit/parser.py
+++ b/electronicparsers/abinit/parser.py
@@ -999,6 +999,7 @@ class AbinitParser(BeyondDFTWorkflowsParser):
             ecut = ecut * ureg.hartree
         sec_method.electronic_model.append(
                 BasisSetContainer(
+                type='plane waves',
                 scope=['wavefunction'],
                 basis_set=[
                     BasisSet(

--- a/electronicparsers/abinit/parser.py
+++ b/electronicparsers/abinit/parser.py
@@ -997,7 +997,7 @@ class AbinitParser(BeyondDFTWorkflowsParser):
         ecut = self.out_parser.get_input_var('ecut', 1)
         if ecut is not None:
             ecut = ecut * ureg.hartree
-        sec_method.electronic_model.append(
+        sec_method.electrons_representation.append(
                 BasisSetContainer(
                 type='plane waves',
                 scope=['wavefunction'],

--- a/electronicparsers/ams/parser.py
+++ b/electronicparsers/ams/parser.py
@@ -26,14 +26,14 @@ from nomad.parsing.file_parser.text_parser import TextParser, Quantity
 from nomad.datamodel.metainfo.simulation.run import Run, Program, TimeRun
 from nomad.datamodel.metainfo.simulation.method import (
     Method, DFT, XCFunctional, Functional, Electronic, BasisSet, Scf, AtomParameters,
-    KMesh
+    KMesh, BasisSetContainer, BasisSetAtomCentered,
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
 )
 from nomad.datamodel.metainfo.simulation.calculation import (
     Calculation, ScfIteration, Dos, DosValues, Energy, EnergyEntry, Forces, ForcesEntry,
-    Charges, ChargesValue, Multipoles, MultipolesEntry, BandEnergies, BandGapDeprecated
+    Charges, ChargesValue, Multipoles, MultipolesEntry, BandEnergies, BandGapDeprecated,
 )
 from nomad.datamodel.metainfo.workflow import Workflow, GeometryOptimization
 from nomad.datamodel.metainfo.simulation.workflow import (
@@ -926,10 +926,21 @@ class AMSParser:
 
         def parse_method(source):
             sec_method = sec_run.m_create(Method)
-            sec_basis_set = sec_method.m_create(BasisSet)
-            sec_basis_set.type = 'numeric AOs'
+            sec_atom_centered = BasisSetAtomCentered()
             for key, val in source.get('confinement', {}).items():
-                setattr(sec_basis_set, key, val)
+                setattr(sec_atom_centered, key, val)
+            sec_method.electronic_model = [
+                BasisSetContainer(
+                    type='atom-centered orbitals',
+                    scope=['wavefunction'],
+                    basis_set=[
+                        BasisSet(
+                            type='numeric AOs',
+                            atom_centered=[sec_atom_centered],
+                        )
+                    ]
+                )
+            ]
 
             for function in source.get('radial_functions', []):
                 sec_atom_param = sec_method.m_create(AtomParameters)

--- a/electronicparsers/ams/parser.py
+++ b/electronicparsers/ams/parser.py
@@ -929,7 +929,7 @@ class AMSParser:
             sec_atom_centered = BasisSetAtomCentered()
             for key, val in source.get('confinement', {}).items():
                 setattr(sec_atom_centered, key, val)
-            sec_method.electronic_model = [
+            sec_method.electrons_representation = [
                 BasisSetContainer(
                     type='atom-centered orbitals',
                     scope=['wavefunction'],

--- a/electronicparsers/atk/parser.py
+++ b/electronicparsers/atk/parser.py
@@ -31,7 +31,7 @@ from nomad.parsing.file_parser import FileParser, TextParser, Quantity
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
     Method, BasisSet, Electronic, Smearing, DFT, XCFunctional, Functional,
-    BasisSetAtomCentered)
+    BasisSetAtomCentered, BasisSetContainer,)
 from nomad.datamodel.metainfo.simulation.system import System, Atoms
 from nomad.datamodel.metainfo.simulation.calculation import (
     Calculation, Energy, EnergyEntry, Forces, ForcesEntry)
@@ -251,9 +251,9 @@ class ATKParser:
                 elif '_C' in xc_functional:
                     sec_xc_functional.correlation.append(Functional(name=xc_functional))
 
-            sec_method.basis_set.append(
-                BasisSet(type='numeric AOs'))
-            sec_method.basis_set[0].atom_centered.append(BasisSetAtomCentered(name='ATK LCAO basis'))
+            # Basis set
+            # TODO: QuantumATK supports multiple types of basis sets: numeric AOs, or plane waves
+            # https://www.synopsys.com/silicon/quantumatk/resources/feature-list.html#lcao
 
             return sec_method
 

--- a/electronicparsers/bigdft/parser.py
+++ b/electronicparsers/bigdft/parser.py
@@ -30,7 +30,7 @@ except Exception:
 from nomad.units import ureg
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
-    Method, DFT, XCFunctional, Functional, Electronic, Scf, BasisSet
+    Method, DFT, XCFunctional, Functional, Electronic, Scf, BasisSet, BasisSetContainer
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
@@ -187,7 +187,15 @@ class BigDFTParser:
 
     def parse_method(self):
         sec_method = self.archive.run[0].m_create(Method)
-        sec_method.basis_set.append(BasisSet(type='real-space grid'))
+        sec_method.electronic_model = [
+            BasisSetContainer(
+                type='real-space grid',
+                scope=['wavefunction'],
+                basis_set=[
+                    BasisSet(type='real-space grid',)
+                ]
+            )
+        ]
         sec_dft = sec_method.m_create(DFT)
 
         data = self._extract('dft', self.yaml_dict, {})

--- a/electronicparsers/bigdft/parser.py
+++ b/electronicparsers/bigdft/parser.py
@@ -187,7 +187,7 @@ class BigDFTParser:
 
     def parse_method(self):
         sec_method = self.archive.run[0].m_create(Method)
-        sec_method.electronic_model = [
+        sec_method.electrons_representation = [
             BasisSetContainer(
                 type='real-space grid',
                 scope=['wavefunction'],

--- a/electronicparsers/castep/metainfo/castep.py
+++ b/electronicparsers/castep/metainfo/castep.py
@@ -1949,16 +1949,9 @@ class System(simulation.system.System):
         repeats=True)
 
 
-class BasisSetCellDependent(simulation.method.BasisSetCellDependent):
+class BasisSet(simulation.method.BasisSet):
 
     m_def = Section(validate=False, extends_base_section=True)
-
-    x_castep_basis_set_planewave_cutoff = Quantity(
-        type=str,
-        shape=[],
-        description='''
-        Temporary storing plane wave cutoff as string
-        ''')
 
     x_castep_size_std_grid = Quantity(
         type=np.dtype(np.float64),

--- a/electronicparsers/castep/parser.py
+++ b/electronicparsers/castep/parser.py
@@ -757,6 +757,7 @@ class CastepParser:
         basis_parameters = self.out_parser.get('title', {}).get('basis set parameters', {})
         sec_method.electronic_model.append(
             BasisSetContainer(
+                type='plane waves',
                 scope=['wavefunction'],
                 basis_set=[
                     BasisSet(

--- a/electronicparsers/castep/parser.py
+++ b/electronicparsers/castep/parser.py
@@ -755,7 +755,7 @@ class CastepParser:
 
         # basis set
         basis_parameters = self.out_parser.get('title', {}).get('basis set parameters', {})
-        sec_method.electronic_model.append(
+        sec_method.electrons_representation.append(
             BasisSetContainer(
                 type='plane waves',
                 scope=['wavefunction'],

--- a/electronicparsers/cp2k/parser.py
+++ b/electronicparsers/cp2k/parser.py
@@ -29,8 +29,8 @@ from nomad.parsing.file_parser import TextParser, Quantity, FileParser, DataText
 from nomad.datamodel.metainfo.simulation.run import (
     Run, Program)
 from nomad.datamodel.metainfo.simulation.method import (
-    Method, DFT, XCFunctional, Functional, BasisSet, BasisSetCellDependent, BasisSetAtomCentered,
-    AtomParameters, Scf, Electronic
+    Method, DFT, XCFunctional, Functional, BasisSet, BasisSetContainer,
+    AtomParameters, Scf, Electronic, BasisSetAtomCentered
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
@@ -1257,29 +1257,50 @@ class CP2KParser:
             md_steps.extend(molecular_dynamics.get('md_step', []))
             parse_calculations(md_steps)
 
-    def parse_method_quickstep(self):
-        sec_run = self.archive.run[-1]
-        sec_method = sec_run.m_create(Method)
-
-        sec_basis = sec_method.m_create(BasisSet)
-        sec_basis.kind = 'wavefunction'
-        sec_basis.type = 'gaussians'
-
-        planewave_cutoff = self.settings.get('qs', {}).get('planewave_cutoff', None)
-        if planewave_cutoff is not None:
-            sec_basis_cell = sec_basis.m_create(BasisSetCellDependent)
-            sec_basis_cell.planewave_cutoff = planewave_cutoff * ureg.hartree
-
+    def _parse_basis_set(self) -> list[BasisSet]:
+        '''Scopes are based on https://10.1016/j.cpc.2004.12.014'''
+        bs_gauss = BasisSet(
+                scope=['kinetic energy', 'electron-core interaction'],
+                type='gaussians',
+            )
         atoms = self.out_parser.get(
             self._calculation_type, {}).get('atomic_kind_information', {}).get('atom', [])
         for atom in atoms:
             basis_set = atom.get('kind_basis_set_name', None)
             if basis_set is not None:
-                sec_basis_atom = sec_basis.m_create(BasisSetAtomCentered)
-                sec_basis_atom.atom_number = self.get_atomic_number(atom.kind_label)
-                sec_basis_atom.name = basis_set
+                ac = BasisSetAtomCentered()
+                ac.atom_number = self.get_atomic_number(atom.kind_label)
+                ac.name = basis_set
+                bs_gauss.atom_centered.append(ac)
+        if bs_gauss.atom_centered:
+            bs_pw = BasisSet(
+                scope=['Hartree energy', 'electron-electron interaction'],
+                type='plane waves',
+                cutoff=self.settings.get('qs', {}).\
+                    get('planewave_cutoff', None) * ureg.hartree,
+            )
+            basis_sets = [bs_pw, bs_gauss]
+        else:
+            bs_pw = BasisSet(
+                scope=['valence'],
+                type='plane waves',
+                cutoff=self.settings.get('qs', {}).\
+                    get('planewave_cutoff', None) * ureg.hartree,
+            )
+            basis_sets = [bs_pw]
+        return basis_sets
 
-        quickstep = self.out_parser.get(self._calculation_type)
+    def parse_method_quickstep(self):
+        sec_run = self.archive.run[-1]
+        sec_method = sec_run.m_create(Method)
+
+        sec_method.electronic_model.append(
+            BasisSetContainer(
+                scope=['wavefunction'],
+                basis_set=self._parse_basis_set(),
+            )
+        )
+        quickstep = self.out_parser.get(self._calculation_type, sec_method)
 
         sec_dft = sec_method.m_create(DFT)
         # electronic structure method

--- a/electronicparsers/cp2k/parser.py
+++ b/electronicparsers/cp2k/parser.py
@@ -1294,13 +1294,13 @@ class CP2KParser:
         sec_run = self.archive.run[-1]
         sec_method = sec_run.m_create(Method)
 
-        sec_method.electronic_model.append(
+        sec_method.electronic_model = [
             BasisSetContainer(
-                type='atom-centered orbitals',
+                type='gaussians + plane waves',
                 scope=['wavefunction'],
                 basis_set=self._parse_basis_set(),
             )
-        )
+        ]
         quickstep = self.out_parser.get(self._calculation_type, sec_method)
 
         sec_dft = sec_method.m_create(DFT)

--- a/electronicparsers/cp2k/parser.py
+++ b/electronicparsers/cp2k/parser.py
@@ -1296,6 +1296,7 @@ class CP2KParser:
 
         sec_method.electronic_model.append(
             BasisSetContainer(
+                type='atom-centered orbitals',
                 scope=['wavefunction'],
                 basis_set=self._parse_basis_set(),
             )

--- a/electronicparsers/cp2k/parser.py
+++ b/electronicparsers/cp2k/parser.py
@@ -1294,7 +1294,7 @@ class CP2KParser:
         sec_run = self.archive.run[-1]
         sec_method = sec_run.m_create(Method)
 
-        sec_method.electronic_model = [
+        sec_method.electrons_representation = [
             BasisSetContainer(
                 type='gaussians + plane waves',
                 scope=['wavefunction'],

--- a/electronicparsers/cpmd/parser.py
+++ b/electronicparsers/cpmd/parser.py
@@ -447,7 +447,7 @@ class CPMDParser:
         cutoff = self.mainfile_parser.get('supercell', {}).get(
             'x_cpmd_wave_function_cutoff')
         if cutoff is not None:
-            sec_method.electronic_model.append(
+            sec_method.electrons_representation.append(
                 BasisSetContainer(
                     scope=['wavefunction'],
                     type='plane waves',

--- a/electronicparsers/cpmd/parser.py
+++ b/electronicparsers/cpmd/parser.py
@@ -33,7 +33,7 @@ from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
 )
 from nomad.datamodel.metainfo.simulation.method import (
-    Method, BasisSet, BasisSetCellDependent
+    Method, BasisSet, BasisSetContainer
 )
 from nomad.datamodel.metainfo.workflow import Workflow, GeometryOptimization, MolecularDynamics
 from nomad.datamodel.metainfo.simulation.workflow import (
@@ -444,13 +444,21 @@ class CPMDParser:
                             break
 
         sec_method = sec_run.m_create(Method)
-        sec_basis = sec_method.m_create(BasisSet)
-        sec_basis.type = 'plane waves'
-        sec_basis.kind = 'wavefunction'
-        cutoff = self.mainfile_parser.get('supercell', {}).get('x_cpmd_wave_function_cutoff', 0.)
-        sec_cell_basis = sec_basis.m_create(BasisSetCellDependent)
-        sec_cell_basis.planewave_cutoff = cutoff * ureg.rydberg
-        sec_cell_basis.name = f'PW_{cutoff}'
+        sec_method.electronic_model.append(
+            BasisSetContainer(
+                scope=['wavefunction'],
+                type='plane waves',
+                basis_set = [
+                    BasisSet(
+                        scope=['valence'],
+                        type='plane waves',
+                    )
+                ]
+            )
+        )
+        cutoff = self.mainfile_parser.get('supercell', {}).get('x_cpmd_wave_function_cutoff')
+        if cutoff is not None:
+            sec_method.electronic_model[0].basis_set[0].cutoff = cutoff * ureg.rydberg
         sec_method.x_cpmd_simulation_parameters = self.mainfile_parser.get_simulation_parameters()
         # TODO xc functionals. The mapping cannot be ascertained
 

--- a/electronicparsers/cpmd/parser.py
+++ b/electronicparsers/cpmd/parser.py
@@ -444,21 +444,22 @@ class CPMDParser:
                             break
 
         sec_method = sec_run.m_create(Method)
-        sec_method.electronic_model.append(
-            BasisSetContainer(
-                scope=['wavefunction'],
-                type='plane waves',
-                basis_set = [
-                    BasisSet(
-                        scope=['valence'],
-                        type='plane waves',
-                    )
-                ]
-            )
-        )
-        cutoff = self.mainfile_parser.get('supercell', {}).get('x_cpmd_wave_function_cutoff')
+        cutoff = self.mainfile_parser.get('supercell', {}).get(
+            'x_cpmd_wave_function_cutoff')
         if cutoff is not None:
-            sec_method.electronic_model[0].basis_set[0].cutoff = cutoff * ureg.rydberg
+            sec_method.electronic_model.append(
+                BasisSetContainer(
+                    scope=['wavefunction'],
+                    type='plane waves',
+                    basis_set = [
+                        BasisSet(
+                            scope=['valence'],
+                            type='plane waves',
+                            cutoff=cutoff * ureg.rydberg,
+                        )
+                    ]
+                )
+            )
         sec_method.x_cpmd_simulation_parameters = self.mainfile_parser.get_simulation_parameters()
         # TODO xc functionals. The mapping cannot be ascertained
 

--- a/electronicparsers/crystal/parser.py
+++ b/electronicparsers/crystal/parser.py
@@ -705,7 +705,7 @@ class CrystalParser:
         method.electronic_model = [
             BasisSetContainer(
                 type='atom-centered orbitals',
-                scope=['wavefunctions'],
+                scope=['wavefunction'],
                 basis_set=[
                     BasisSet(
                         type='gaussians',  # the scope can fluctuate depending on the use of ECPs

--- a/electronicparsers/crystal/parser.py
+++ b/electronicparsers/crystal/parser.py
@@ -702,7 +702,7 @@ class CrystalParser:
                         )
                         section_basis_sets[-1].x_crystal_section_shell.append(section_shell)
 
-        method.electronic_model = [
+        method.electrons_representation = [
             BasisSetContainer(
                 type='atom-centered orbitals',
                 scope=['wavefunction'],

--- a/electronicparsers/crystal/parser.py
+++ b/electronicparsers/crystal/parser.py
@@ -31,7 +31,8 @@ from nomad.datamodel.metainfo.simulation.run import Run, Program, TimeRun
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms)
 from nomad.datamodel.metainfo.simulation.method import (
-    Method, BasisSet, Electronic, Scf, DFT, XCFunctional, Functional, BasisSetAtomCentered
+    Method, BasisSet, Electronic, Scf, DFT, XCFunctional, Functional,
+    BasisSetAtomCentered, BasisSetContainer,
 )
 from nomad.datamodel.metainfo.simulation.calculation import (
     Calculation, ScfIteration, Energy, EnergyEntry, Forces, ForcesEntry, BandStructure,
@@ -679,7 +680,40 @@ class CrystalParser:
 
         # Method
         method = run.m_create(Method)
-        method.basis_set.append(BasisSet(type='gaussians'))
+
+        # Basis set
+        basis_set = out["basis_set"]
+        covered_species = set()
+        section_basis_sets: list(BasisSetAtomCentered) = []
+        if basis_set is not None:
+            for bs in basis_set["basis_sets"]:  # pylint: disable=E1136
+                atomic_number = label_to_atomic_number(bs["species"][1])
+                shells = bs["shells"]
+                if atomic_number != covered_species and shells is not None:
+                    section_basis_sets.append(
+                        BasisSetAtomCentered(atom_number=atomic_number,)
+                    )
+                    covered_species.add(atomic_number)
+                    for shell in shells:
+                        section_shell = x_crystal_section_shell(
+                            x_crystal_shell_range=str(shell["shell_range"]),
+                            x_crystal_shell_type=shell["shell_type"],
+                            x_crystal_shell_coefficients=np.array(shell["shell_coefficients"]),
+                        )
+                        section_basis_sets[-1].x_crystal_section_shell.append(section_shell)
+
+        method.electronic_model = [
+            BasisSetContainer(
+                type='atom-centered orbitals',
+                scope=['wavefunctions'],
+                basis_set=[
+                    BasisSet(
+                        type='gaussians',  # the scope can fluctuate depending on the use of ECPs
+                        atom_centered=section_basis_sets,
+                    )
+                ]
+            )
+        ]
 
         method.electronic = Electronic(method='DFT')
         method.scf = Scf(
@@ -763,21 +797,6 @@ class CrystalParser:
         method.x_crystal_convergence_deltap = out["convergenge_deltap"]
         method.x_crystal_n_k_points_ibz = out["n_k_points_ibz"]
         method.x_crystal_n_k_points_gilat = out["n_k_points_gilat"]
-        basis_set = out["basis_set"]
-        covered_species = set()
-        if basis_set is not None:
-            for bs in basis_set["basis_sets"]:  # pylint: disable=E1136
-                atomic_number = label_to_atomic_number(bs["species"][1])
-                shells = bs["shells"]
-                if atomic_number != covered_species and shells is not None:
-                    section_basis_set = method.basis_set[-1].m_create(BasisSetAtomCentered)
-                    section_basis_set.atom_number = atomic_number
-                    covered_species.add(atomic_number)
-                    for shell in shells:
-                        section_shell = section_basis_set.m_create(x_crystal_section_shell)
-                        section_shell.x_crystal_shell_range = str(shell["shell_range"])
-                        section_shell.x_crystal_shell_type = shell["shell_type"]
-                        section_shell.x_crystal_shell_coefficients = np.array(shell["shell_coefficients"])
 
         # SCC
         scc = run.m_create(Calculation)

--- a/electronicparsers/dmol3/parser.py
+++ b/electronicparsers/dmol3/parser.py
@@ -333,7 +333,7 @@ class Dmol3Parser:
         # section method
         sec_method = sec_run.m_create(Method)
         # basis set
-        sec_method.electronic_model = [
+        sec_method.electrons_representation = [
             BasisSetContainer(
                 type='atom-centered orbitals',
                 scope=['wavefunction'],

--- a/electronicparsers/dmol3/parser.py
+++ b/electronicparsers/dmol3/parser.py
@@ -26,7 +26,7 @@ from datetime import datetime
 from nomad.units import ureg
 from nomad.parsing.file_parser import TextParser, Quantity
 from nomad.datamodel.metainfo.simulation.run import Run, Program, TimeRun
-from nomad.datamodel.metainfo.simulation.method import Method, BasisSet
+from nomad.datamodel.metainfo.simulation.method import Method, BasisSet, BasisSetContainer
 from nomad.datamodel.metainfo.simulation.system import System, Atoms
 from nomad.datamodel.metainfo.simulation.calculation import (
     Calculation, ScfIteration, Energy, EnergyEntry, BandEnergies, Charges, Multipoles,
@@ -333,7 +333,18 @@ class Dmol3Parser:
         # section method
         sec_method = sec_run.m_create(Method)
         # basis set
-        sec_method.basis_set.append(BasisSet(type='numeric AOs'))
+        sec_method.electronic_model = [
+            BasisSetContainer(
+                type='atom-centered orbitals',
+                scope=['wavefunction'],
+                basis_set=[
+                        BasisSet(
+                        type='numeric AOs',
+                        scope=['full-electron'],
+                    )
+                ]
+            )
+        ]
         # simulation parameters
         for key, val in self.mainfile_parser.simulation_parameters.items():
             if key == 'scf_diis':

--- a/electronicparsers/elk/parser.py
+++ b/electronicparsers/elk/parser.py
@@ -25,7 +25,8 @@ from nomad.units import ureg
 from nomad.parsing.file_parser import TextParser, Quantity, DataTextParser
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
-    Method, BasisSet, DFT, XCFunctional, Functional, Electronic, Smearing
+    Method, BasisSet, DFT, XCFunctional, Functional, Electronic, Smearing,
+    BasisSetContainer,
 )
 from nomad.datamodel.metainfo.simulation.system import System, Atoms
 from nomad.datamodel.metainfo.simulation.calculation import (
@@ -269,7 +270,12 @@ class ElkParser:
         sec_run.program = Program(version=self.mainfile_parser.get('program_version', ''))
 
         sec_method = sec_run.m_create(Method)
-        sec_method.basis_set.append(BasisSet(type='(L)APW+lo'))
+        sec_method.electronic_model = [
+            BasisSetContainer(
+                type='(L)APW+lo',
+                scope=['wavefunction'],
+            )
+        ]
         # xc functional
         sec_xc_functional = XCFunctional()
         for name in self._xc_map.get(self.mainfile_parser.xc_functional, []):

--- a/electronicparsers/elk/parser.py
+++ b/electronicparsers/elk/parser.py
@@ -270,7 +270,7 @@ class ElkParser:
         sec_run.program = Program(version=self.mainfile_parser.get('program_version', ''))
 
         sec_method = sec_run.m_create(Method)
-        sec_method.electronic_model = [
+        sec_method.electrons_representation = [
             BasisSetContainer(
                 type='(L)APW+lo',
                 scope=['wavefunction'],

--- a/electronicparsers/exciting/parser.py
+++ b/electronicparsers/exciting/parser.py
@@ -1602,21 +1602,8 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
                     bs_val.orbital.append(orbital)
 
             if not sec_method.electronic_model:
-                compound_type = ''
-                for orbital in bs_val.orbital or []:
-                    if orbital.type == 'APW' and not compound_type:
-                        compound_type = 'APW'
-                    elif orbital.type == 'LAPW' and not compound_type:
-                        compound_type = 'LAPW'
-                    elif orbital.type in ['APW', 'LAPW']\
-                    and compound_type in ['APW', 'LAPW']\
-                    and orbital.type != compound_type:
-                        compound_type = '(L)APW'
-                    elif orbital.type == 'LO' and 'lo' == compound_type[-2:]:
-                        compound_type += '+lo'
                 sec_method.electronic_model = [
                     BasisSetContainer(
-                        type=compound_type,
                         scope=['wavefunction'],
                         basis_set=[
                             BasisSet(

--- a/electronicparsers/exciting/parser.py
+++ b/electronicparsers/exciting/parser.py
@@ -1601,8 +1601,8 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
                         )
                     bs_val.orbital.append(orbital)
 
-            if not sec_method.electronic_model:
-                sec_method.electronic_model = [
+            if not sec_method.electrons_representation:
+                sec_method.electrons_representation = [
                     BasisSetContainer(
                         scope=['wavefunction'],
                         basis_set=[
@@ -1614,7 +1614,7 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
                         ]
                     )
                 ]
-            sec_method.electronic_model[0].basis_set.append(bs_val)
+            sec_method.electrons_representation[0].basis_set.append(bs_val)
 
 
     def parse_file(self, name, section, filepath=None):

--- a/electronicparsers/exciting/parser.py
+++ b/electronicparsers/exciting/parser.py
@@ -1601,11 +1601,22 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
                         )
                     bs_val.orbital.append(orbital)
 
-            # Compose basis set  # TODO: the overall behaviour of the parser should change so composition is done at another level
             if not sec_method.electronic_model:
+                compound_type = ''
+                for orbital in bs_val.orbital or []:
+                    if orbital.type == 'APW' and not compound_type:
+                        compound_type = 'APW'
+                    elif orbital.type == 'LAPW' and not compound_type:
+                        compound_type = 'LAPW'
+                    elif orbital.type in ['APW', 'LAPW']\
+                    and compound_type in ['APW', 'LAPW']\
+                    and orbital.type != compound_type:
+                        compound_type = '(L)APW'
+                    elif orbital.type == 'LO' and 'lo' == compound_type[-2:]:
+                        compound_type += '+lo'
                 sec_method.electronic_model = [
                     BasisSetContainer(
-                        type='(L)APW+lo',
+                        type=compound_type,
                         scope=['wavefunction'],
                         basis_set=[
                             BasisSet(

--- a/electronicparsers/exciting/parser.py
+++ b/electronicparsers/exciting/parser.py
@@ -1594,7 +1594,7 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
                     for order, energy_parameter in enumerate(energy_parameters):
                         orbital = OrbitalAPW(
                             l_quantum_number=l,
-                            type='lo',
+                            type='LO',
                             order=order,
                             energy_parameter=energy_parameter * ureg.hartree,
                             update=species_data['default']['searchE'],
@@ -1603,10 +1603,19 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
 
             # Compose basis set  # TODO: the overall behaviour of the parser should change so composition is done at another level
             if not sec_method.electronic_model:
-                sec_method.electronic_model = [BasisSetContainer(
-                    type='(L)APW+lo',
-                    scope=['wavefunction'],
-                )]
+                sec_method.electronic_model = [
+                    BasisSetContainer(
+                        type='(L)APW+lo',
+                        scope=['wavefunction'],
+                        basis_set=[
+                            BasisSet(
+                                type='plane waves',
+                                scope=['valence'],
+                                cutoff_fractional=self.input_xml_parser.get('xs/cutoffapw', 7.),
+                            ),
+                        ]
+                    )
+                ]
             sec_method.electronic_model[0].basis_set.append(bs_val)
 
 

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -1516,7 +1516,7 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
         # Basis set
         sec_method.electronic_model = [
             BasisSetContainer(
-                type='atom-centered',
+                type='atom-centered orbitals',
                 scope=['wavefunction'],
                 basis_set=[
                     BasisSet(

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -27,7 +27,7 @@ from nomad.parsing.file_parser import TextParser, Quantity, DataTextParser
 from nomad.datamodel.metainfo.simulation.run import Run, Program, TimeRun
 from nomad.datamodel.metainfo.simulation.method import (
     Electronic, Method, XCFunctional, Functional, HubbardKanamoriModel, AtomParameters, DFT,
-    BasisSet, GW, KMesh, FrequencyMesh
+    BasisSet, GW, KMesh, FrequencyMesh, BasisSetContainer,
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
@@ -1513,7 +1513,19 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
         sec_kmesh.grid = self.out_parser.get('k_grid')
         sec_kmesh.offset = self.out_parser.get('k_offset')
 
-        sec_method.basis_set.append(BasisSet(type='numeric AOs'))
+        # Basis set
+        sec_method.electronic_model = [
+            BasisSetContainer(
+                type='atom-centered',
+                scope=['wavefunction'],
+                basis_set=[
+                    BasisSet(
+                        type='numeric AOs',
+                        scope=['full-electron'],
+                    )
+                ]
+            )
+        ]
         sec_dft = sec_method.m_create(DFT)
         sec_electronic = sec_method.m_create(Electronic)
         sec_electronic.method = 'DFT'

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -1514,7 +1514,7 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
         sec_kmesh.offset = self.out_parser.get('k_offset')
 
         # Basis set
-        sec_method.electronic_model = [
+        sec_method.electrons_representation = [
             BasisSetContainer(
                 type='atom-centered orbitals',
                 scope=['wavefunction'],

--- a/electronicparsers/fleur/metainfo/fleur.py
+++ b/electronicparsers/fleur/metainfo/fleur.py
@@ -513,6 +513,7 @@ class AtomParameters(simulation.method.AtomParameters):
     x_fleur_logarithmic_increment = Quantity(
         type=np.dtype(np.float64),
         shape=[],
+        unit='meter',
         description='''
         logarithmic increment
         ''')

--- a/electronicparsers/fleur/metainfo/fleur.py
+++ b/electronicparsers/fleur/metainfo/fleur.py
@@ -499,16 +499,9 @@ class Method(simulation.method.Method):
         repeats=True)
 
 
-class AtomParameters(simulation.method.AtomParameters):
+class MuffinTinAPW(simulation.method.MuffinTinAPW):
 
     m_def = Section(validate=False, extends_base_section=True)
-
-    x_fleur_mt_gridpoints = Quantity(
-        type=np.dtype(np.int32),
-        shape=[],
-        description='''
-        muffin-tin gridpoints
-        ''')
 
     x_fleur_logarithmic_increment = Quantity(
         type=np.dtype(np.float64),
@@ -518,8 +511,17 @@ class AtomParameters(simulation.method.AtomParameters):
         logarithmic increment
         ''')
 
+    x_fleur_spherical_harmonics_density_cutoff = Quantity(
+        type=np.dtype(np.int32),
+        shape=[],
+        description='''
+        ''')
+
 
 class BasisSet(simulation.method.BasisSet):
+
+    m_def = Section(validate=False, extends_base_section=True)
+
     x_fleur_coretail = Quantity(
         type=bool,
         shape=[],
@@ -534,12 +536,6 @@ class BasisSet(simulation.method.BasisSet):
     )
 
     x_fleur_relativistic_core = Quantity(
-        type=bool,
-        shape=[],
-        description='''
-        ''')
-
-    x_fleur_frozen_core = Quantity(
         type=bool,
         shape=[],
         description='''

--- a/electronicparsers/fleur/metainfo/fleur.py
+++ b/electronicparsers/fleur/metainfo/fleur.py
@@ -518,22 +518,33 @@ class AtomParameters(simulation.method.AtomParameters):
         logarithmic increment
         ''')
 
-    x_fleur_lexpansion_cutoff = Quantity(
-        type=np.dtype(np.float64),
+
+class BasisSet(simulation.method.BasisSet):
+    x_fleur_coretail = Quantity(
+        type=bool,
         shape=[],
         description='''
-        l-expansion cutoff
         ''')
 
-    x_fleur_lexpansion_lo_cutoff = Quantity(
-        type=np.dtype(np.float64),
+    x_fleur_coretail_cutoff = Quantity(
+        type=np.dtype(np.int32),
         shape=[],
         description='''
-        If present the APW+lo approach will be used.
-        This is the cutoff defining the lmax up to which LAPWs are used
-        if no APW+lo local orbital is defined for the respective l.
-        See also the respective article by G.K.H. Madsen.
+        '''
+    )
+
+    x_fleur_relativistic_core = Quantity(
+        type=bool,
+        shape=[],
+        description='''
         ''')
+
+    x_fleur_frozen_core = Quantity(
+        type=bool,
+        shape=[],
+        description='''
+        ''')
+
 
 class XCFunctional(simulation.method.XCFunctional):
 

--- a/electronicparsers/fleur/metainfo/fleur.py
+++ b/electronicparsers/fleur/metainfo/fleur.py
@@ -20,7 +20,7 @@ import numpy as np            # pylint: disable=unused-import
 
 from nomad.metainfo import (  # pylint: disable=unused-import
     MSection, MCategory, Category, Package, Quantity, Section, SubSection, SectionProxy,
-    Reference, JSON
+    Reference, JSON, MEnum
 )
 from nomad.datamodel.metainfo import simulation
 
@@ -497,6 +497,16 @@ class Method(simulation.method.Method):
     x_fleur_section_XC = SubSection(
         sub_section=SectionProxy('x_fleur_section_XC'),
         repeats=True)
+
+
+class OrbitalAPW(simulation.method.OrbitalAPW):
+    x_fleur_lo_type = Quantity(
+        type=MEnum('SCLO', 'HELO'),
+        shape=[],
+        description='''
+        Fleur demarcation of the LO type used.
+        https://www.flapw.de/MaX-6.0/documentation/localOrbitalSetup/
+        ''')
 
 
 class BasisSet(simulation.method.BasisSet):

--- a/electronicparsers/fleur/metainfo/fleur.py
+++ b/electronicparsers/fleur/metainfo/fleur.py
@@ -499,25 +499,6 @@ class Method(simulation.method.Method):
         repeats=True)
 
 
-class MuffinTinAPW(simulation.method.MuffinTinAPW):
-
-    m_def = Section(validate=False, extends_base_section=True)
-
-    x_fleur_logarithmic_increment = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        unit='meter',
-        description='''
-        logarithmic increment
-        ''')
-
-    x_fleur_spherical_harmonics_density_cutoff = Quantity(
-        type=np.dtype(np.int32),
-        shape=[],
-        description='''
-        ''')
-
-
 class BasisSet(simulation.method.BasisSet):
 
     m_def = Section(validate=False, extends_base_section=True)

--- a/electronicparsers/fleur/metainfo/fleur.py
+++ b/electronicparsers/fleur/metainfo/fleur.py
@@ -265,34 +265,6 @@ class System(simulation.system.System):
         x_fleur_number_of_core_levels
         ''')
 
-    x_fleur_lexpansion_cutoff = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        description='''
-        l-expansion cutoff
-        ''')
-
-    x_fleur_mt_gridpoints = Quantity(
-        type=np.dtype(np.int32),
-        shape=[],
-        description='''
-        muffin-tin gridpoints
-        ''')
-
-    x_fleur_mt_radius = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        description='''
-        muffin-tin radius
-        ''')
-
-    x_fleur_logarythmic_increment = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        description='''
-        logarythmic increment
-        ''')
-
     x_fleur_k_max = Quantity(
         type=np.dtype(np.float64),
         shape=[],
@@ -526,6 +498,41 @@ class Method(simulation.method.Method):
         sub_section=SectionProxy('x_fleur_section_XC'),
         repeats=True)
 
+
+class AtomParameters(simulation.method.AtomParameters):
+
+    m_def = Section(validate=False, extends_base_section=True)
+
+    x_fleur_mt_gridpoints = Quantity(
+        type=np.dtype(np.int32),
+        shape=[],
+        description='''
+        muffin-tin gridpoints
+        ''')
+
+    x_fleur_logarithmic_increment = Quantity(
+        type=np.dtype(np.float64),
+        shape=[],
+        description='''
+        logarithmic increment
+        ''')
+
+    x_fleur_lexpansion_cutoff = Quantity(
+        type=np.dtype(np.float64),
+        shape=[],
+        description='''
+        l-expansion cutoff
+        ''')
+
+    x_fleur_lexpansion_lo_cutoff = Quantity(
+        type=np.dtype(np.float64),
+        shape=[],
+        description='''
+        If present the APW+lo approach will be used.
+        This is the cutoff defining the lmax up to which LAPWs are used
+        if no APW+lo local orbital is defined for the respective l.
+        See also the respective article by G.K.H. Madsen.
+        ''')
 
 class XCFunctional(simulation.method.XCFunctional):
 

--- a/electronicparsers/fleur/parser.py
+++ b/electronicparsers/fleur/parser.py
@@ -666,7 +666,7 @@ class FleurParser:
                 )
             )
             em.basis_set = [*em.basis_set, *self.parser.get_basis_sets()]
-            sec_method.electronic_model.append(em)
+            sec_method.electrons_representation.append(em)
 
         electronic = self.parser.electronic
         if electronic is not None:

--- a/electronicparsers/fleur/parser.py
+++ b/electronicparsers/fleur/parser.py
@@ -319,7 +319,7 @@ class XMLParser(TextParser):
                     if (l, order) in [lo.keys() for lo in los]:
                         orbital.append(
                             OrbitalAPW(
-                                type='local orbital',
+                                type='LO',
                                 energy_parameter_n=lo[(l, order)][0],
                                 l_quantum_number=l,
                                 core_level=False,

--- a/electronicparsers/gamess/parser.py
+++ b/electronicparsers/gamess/parser.py
@@ -608,7 +608,7 @@ class GamessParser:
 
         # Basis set
         gbasis = sec_method.x_gamess_basis_options.get('GBASIS', 'NONE')
-        sec_method.electronic_model = [
+        sec_method.electrons_representation = [
             BasisSetContainer(
                 type='atom-centered orbitals',
                 scope=['wavefunction'],
@@ -618,7 +618,7 @@ class GamessParser:
             )
         ]
         for basis_set in self._basis_set_map.get(gbasis, []):
-            sec_method.electronic_model[0].basis_set[0].atom_centered.append(
+            sec_method.electrons_representation[0].basis_set[0].atom_centered.append(
                 BasisSetAtomCentered(
                     name=basis_set.get('name'),
                     formula=resolve_basis(gbasis),

--- a/electronicparsers/gamess/parser.py
+++ b/electronicparsers/gamess/parser.py
@@ -27,7 +27,7 @@ from nomad.parsing.file_parser import TextParser, Quantity
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
     Method, AtomParameters, DFT, XCFunctional, Functional, Electronic, BasisSet,
-    BasisSetAtomCentered)
+    BasisSetAtomCentered, BasisSetContainer)
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
 )
@@ -606,12 +606,24 @@ class GamessParser:
 
             return f'{igauss}{gbasis}{plus}{symbol}{orb_suffix}'
 
+        # Basis set
         gbasis = sec_method.x_gamess_basis_options.get('GBASIS', 'NONE')
-        sec_basis = sec_method.m_create(BasisSet)
-        sec_basis.name = resolve_basis(gbasis)
+        sec_method.electronic_model = [
+            BasisSetContainer(
+                type='atom-centered orbitals',
+                scope=['wavefunction'],
+                basis_set = [
+                    BasisSet(type='gaussians',)
+                ]
+            )
+        ]
         for basis_set in self._basis_set_map.get(gbasis, []):
-            sec_atom_basis = sec_basis.m_create(BasisSetAtomCentered)
-            sec_atom_basis.name = basis_set.get('name')
+            sec_method.electronic_model[0].basis_set[0].atom_centered.append(
+                BasisSetAtomCentered(
+                    name=basis_set.get('name'),
+                    formula=resolve_basis(gbasis),
+                )
+            )
 
         # electronic structure method
         sec_method.electronic = Electronic()

--- a/electronicparsers/gaussian/parser.py
+++ b/electronicparsers/gaussian/parser.py
@@ -1051,8 +1051,8 @@ class GaussianParser:
                 n_parsed=len(basis_sets)))
         for basis_set in basis_sets:
             bs = BasisSet(
-                scope=['full-electron'],
                 type='gaussians',
+                scope=['full-electron'],
             )
             for _ in self._basis_set_map.get(basis_set[0], []):
                 # TODO need to adjust basis_set atom centered to take multiple entries
@@ -1060,7 +1060,7 @@ class GaussianParser:
                 bs.atom_centered.append(BasisSetAtomCentered(name=basis_set[1]))
         sec_method.electronic_model = [
             BasisSetContainer(
-                type='atom-centered',
+                type='atom-centered orbitals',
                 scope=['wavefunction'],
                 basis_set=[bs],
             )

--- a/electronicparsers/gaussian/parser.py
+++ b/electronicparsers/gaussian/parser.py
@@ -9,7 +9,8 @@ from nomad.units import ureg
 from nomad.parsing.file_parser.text_parser import TextParser, Quantity
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
-    Electronic, Method, XCFunctional, Functional, DFT, BasisSet, BasisSetAtomCentered
+    Electronic, Method, XCFunctional, Functional, DFT, BasisSet, BasisSetAtomCentered,
+    BasisSetContainer,
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
@@ -1044,18 +1045,26 @@ class GaussianParser:
                 sec_elstruc_method.x_gaussian_electronic_structure_method = '%s%s' % (
                     prefix, entry['name'])
 
+        # Basis set
         if len(basis_sets) != 1:
             self.logger.error('Found multiple or no basis set', data=dict(
                 n_parsed=len(basis_sets)))
         for basis_set in basis_sets:
-            sec_basis = sec_method.m_create(BasisSet)
-            sec_basis.type = 'gaussians'
-            sec_basis.name = basis_set[0]
+            bs = BasisSet(
+                scope=['full-electron'],
+                type='gaussians',
+            )
             for _ in self._basis_set_map.get(basis_set[0], []):
                 # TODO need to adjust basis_set atom centered to take multiple entries
-                sec_basis_set_atom_centered = sec_basis.m_create(BasisSetAtomCentered)
                 # old parser writes the full name of basis set here not the name on map
-                sec_basis_set_atom_centered.name = basis_set[1]
+                bs.atom_centered.append(BasisSetAtomCentered(name=basis_set[1]))
+        sec_method.electronic_model = [
+            BasisSetContainer(
+                type='atom-centered',
+                scope=['wavefunction'],
+                basis_set=[bs],
+            )
+        ]
 
         if len(xc_functionals) != 1:
             self.logger.error('Found multiple or no xc functional', data=dict(

--- a/electronicparsers/gaussian/parser.py
+++ b/electronicparsers/gaussian/parser.py
@@ -1058,7 +1058,7 @@ class GaussianParser:
                 # TODO need to adjust basis_set atom centered to take multiple entries
                 # old parser writes the full name of basis set here not the name on map
                 bs.atom_centered.append(BasisSetAtomCentered(name=basis_set[1]))
-        sec_method.electronic_model = [
+        sec_method.electrons_representation = [
             BasisSetContainer(
                 type='atom-centered orbitals',
                 scope=['wavefunction'],

--- a/electronicparsers/gpaw/parser.py
+++ b/electronicparsers/gpaw/parser.py
@@ -7,8 +7,8 @@ from nomad.units import ureg
 from nomad.parsing.file_parser import FileParser, TarParser, XMLParser, DataTextParser
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
-    Electronic, Method, DFT, Smearing, XCFunctional, Functional, BasisSet, BasisSetAtomCentered,
-    BasisSetCellDependent, Electronic, Scf
+    Electronic, Method, DFT, Smearing, XCFunctional, Functional, BasisSet,
+    BasisSetContainer, Electronic, Scf
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
@@ -288,22 +288,6 @@ class GPAWParser:
         unit = units_map.get(p_unit, p_unit) if p_unit else unit
         return val * unit
 
-    def get_basis_set_name(self, basis_set):
-        if basis_set == 'plane waves':
-            pw_cutoff = self.parser.get_parameter('planewavecutoff')
-            pw_cutoff = self.apply_unit(pw_cutoff, 'energyunit')
-            return 'PW_%.1f_Ry' % (pw_cutoff.to('rydberg').magnitude)
-        elif basis_set == 'real space grid':
-            cell = self.parser.get_array('unitcell')
-            ngpts = self.parser.get_array_dimension('ngpts')
-            if cell is None or ngpts is None:
-                return
-            h_grid = np.linalg.norm(cell, axis=1) / np.array(ngpts[:3])
-            h_grid = self.apply_unit(np.sum(h_grid) / 3.0, 'lengthunit')
-            return 'GR_%.1f' % (h_grid.to('fm').magnitude)
-        elif basis_set == 'numeric AOs':
-            return self.parser.get_parameter('basisset')
-
     def get_mode(self):
         mode = self.parser.get_parameter('mode')
         if isinstance(mode, dict):
@@ -326,24 +310,40 @@ class GPAWParser:
 
     def parse_method(self):
         sec_method = self.archive.run[-1].m_create(Method)
-        sec_basis_set = sec_method.m_create(BasisSet)
+
+        # Basis Set
         mode = self.get_mode()
+        bs: BasisSet = None
         if mode == 'pw':
-            sec_basis = sec_basis_set.m_create(BasisSetCellDependent)
             pw_cutoff = self.parser.get_parameter('planewavecutoff')
             pw_cutoff = self.apply_unit(pw_cutoff, 'energyunit')
-            sec_basis.kind = 'plane waves'
-            sec_basis.planewave_cutoff = pw_cutoff
-            sec_basis.name = self.get_basis_set_name('plane waves')
+            bs = BasisSet(
+                scope=['valence'],
+                type='plane waves',
+                cutoff=pw_cutoff,
+            )
         elif mode == 'fd':
-            sec_basis = sec_basis_set.m_create(BasisSetCellDependent)
-            sec_basis.kind = 'real space grid'
-            sec_basis.name = self.get_basis_set_name('real space grid')
+            bs = BasisSet(
+                scope=['full-electron'],  # TODO check
+                type='real-space grid',
+            )
+            cell = self.parser.get_array('unitcell')
+            ngpts = self.apply_unit(self.parser.get_array_dimension('ngpts'), 'lengthunit')
+            if cell.any() and ngpts.all():
+                h_grid = np.linalg.norm(cell, axis=1) / np.array(ngpts[:3])
+                bs.grid_spacing = self.apply_unit(h_grid, 'lengthunit')
         elif mode == 'lcao':
-            sec_basis = sec_basis_set.m_create(BasisSetAtomCentered)
-            sec_basis.kind = 'numeric AOs'
-            sec_basis.name = self.get_basis_set_name('numeric AOs')
-        sec_basis_set.type = sec_basis.kind
+            bs = BasisSet(
+                scope=['full-electron'],  # TODO check
+                type='numerical AOs',
+            )
+        if bs:
+            sec_method.electronic_model.append(
+                BasisSetContainer(
+                    scope=['wavefunction'],
+                    basis_set=[bs],
+                )
+            )
 
         sec_electronic = sec_method.m_create(Electronic)
         sec_electronic.relativity_method = 'pseudo_scalar_relativistic'

--- a/electronicparsers/gpaw/parser.py
+++ b/electronicparsers/gpaw/parser.py
@@ -345,7 +345,7 @@ class GPAWParser:
                 type='numeric AOs',
             )
         if bs:
-            sec_method.electronic_model.append(
+            sec_method.electrons_representation.append(
                 BasisSetContainer(
                     type=_basisset_type_to_container(bs.type),
                     scope=['wavefunction'],

--- a/electronicparsers/gpaw/parser.py
+++ b/electronicparsers/gpaw/parser.py
@@ -335,7 +335,7 @@ class GPAWParser:
         elif mode == 'lcao':
             bs = BasisSet(
                 scope=['full-electron'],  # TODO check
-                type='numerical AOs',
+                type='numeric AOs',
             )
         if bs:
             sec_method.electronic_model.append(

--- a/electronicparsers/gpaw/parser.py
+++ b/electronicparsers/gpaw/parser.py
@@ -312,6 +312,13 @@ class GPAWParser:
         sec_method = self.archive.run[-1].m_create(Method)
 
         # Basis Set
+        def _basisset_type_to_container(basisset_type: str) -> str:
+            for option  in ('real-space grid', 'plane waves'):
+                if basisset_type == option:
+                    return basisset_type
+            if basisset_type == 'numeric AOs':
+                return 'atom-centered orbitals'
+
         mode = self.get_mode()
         bs: BasisSet = None
         if mode == 'pw':
@@ -340,6 +347,7 @@ class GPAWParser:
         if bs:
             sec_method.electronic_model.append(
                 BasisSetContainer(
+                    type=_basisset_type_to_container(bs.type),
                     scope=['wavefunction'],
                     basis_set=[bs],
                 )

--- a/electronicparsers/nwchem/parser.py
+++ b/electronicparsers/nwchem/parser.py
@@ -25,7 +25,8 @@ from nomad.units import ureg
 from nomad.parsing.file_parser import TextParser, Quantity
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
-    Electronic, Method, DFT, XCFunctional, Functional, BasisSet, Scf
+    Electronic, Method, DFT, XCFunctional, Functional, BasisSet, Scf,
+    BasisSetContainer,
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
@@ -454,8 +455,15 @@ class NWChemParser:
         if total_charge is not None:
             sec_electronic.charge = total_charge
 
-        sec_basis = sec_method.m_create(BasisSet)
+        sec_basis = BasisSet()
         sec_basis.type = 'plane waves' if self.out_parser.get('pw') is not None else 'gaussians'
+        sec_basis.scope = ['valence'] if sec_basis.type == 'gaussians' else []  # TODO: add distinction for ECP
+        sec_method.electronic_model = [
+            BasisSetContainer(
+                scope=['wavefunction'],
+                basis_set=[sec_basis],
+            )
+        ]
 
         return sec_method
 

--- a/electronicparsers/nwchem/parser.py
+++ b/electronicparsers/nwchem/parser.py
@@ -458,8 +458,10 @@ class NWChemParser:
         sec_basis = BasisSet()
         sec_basis.type = 'plane waves' if self.out_parser.get('pw') is not None else 'gaussians'
         sec_basis.scope = ['valence'] if sec_basis.type == 'gaussians' else []  # TODO: add distinction for ECP
+        full_type = 'plane waves' if sec_basis.type == 'plane waves' else 'atom-centered orbitals'
         sec_method.electronic_model = [
             BasisSetContainer(
+                type=full_type,
                 scope=['wavefunction'],
                 basis_set=[sec_basis],
             )

--- a/electronicparsers/nwchem/parser.py
+++ b/electronicparsers/nwchem/parser.py
@@ -459,7 +459,7 @@ class NWChemParser:
         sec_basis.type = 'plane waves' if self.out_parser.get('pw') is not None else 'gaussians'
         sec_basis.scope = ['valence'] if sec_basis.type == 'gaussians' else []  # TODO: add distinction for ECP
         full_type = 'plane waves' if sec_basis.type == 'plane waves' else 'atom-centered orbitals'
-        sec_method.electronic_model = [
+        sec_method.electrons_representation = [
             BasisSetContainer(
                 type=full_type,
                 scope=['wavefunction'],

--- a/electronicparsers/octopus/parser.py
+++ b/electronicparsers/octopus/parser.py
@@ -823,7 +823,7 @@ class OctopusParser:
         sec_dft = sec_method.m_create(DFT)
 
         # basis set
-        sec_method.electronic_model.append(
+        sec_method.electrons_representation.append(
             BasisSetContainer(
                 type='real-space grid',
                 scope=['wavefunction'],

--- a/electronicparsers/octopus/parser.py
+++ b/electronicparsers/octopus/parser.py
@@ -10,7 +10,7 @@ from nomad.units import ureg
 from nomad.parsing.file_parser import TextParser, Quantity
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
-    Electronic, Functional, Smearing, Method, DFT, BasisSet, BasisSetCellDependent,
+    Electronic, Functional, Smearing, Method, DFT, BasisSet, BasisSetContainer,
     XCFunctional, KMesh
 )
 from nomad.datamodel.metainfo.simulation.system import (
@@ -823,10 +823,18 @@ class OctopusParser:
         sec_dft = sec_method.m_create(DFT)
 
         # basis set
-        sec_basis = sec_method.m_create(BasisSet)
-        sec_basis.type = 'real-space grid'
-        sec_basis_set = sec_basis.m_create(BasisSetCellDependent)
-        sec_basis_set.kind = 'realspace_grids'
+        sec_method.electronic_model.append(
+            BasisSetContainer(
+                type='real-space grid',
+                scope=['wavefunction'],
+                basis_set=[
+                    BasisSet(
+                        scope=['valence'],
+                        type='real-space grid',
+                    )
+                ]
+            )
+        )
 
         # smearing
         smearing_function = self._smearing_functions.get(self.info.get('SmearingFunction'), None)

--- a/electronicparsers/onetep/metainfo/onetep.py
+++ b/electronicparsers/onetep/metainfo/onetep.py
@@ -2585,16 +2585,9 @@ class System(simulation.system.System):
         repeats=True)
 
 
-class BasisSetCellDependent(simulation.method.BasisSetCellDependent):
+class BasisSet(simulation.method.BasisSet):
 
     m_def = Section(validate=False, extends_base_section=True)
-
-    x_onetep_basis_set_planewave_cutoff = Quantity(
-        type=str,
-        shape=[],
-        description='''
-        Temporary storing plane wave cutoff as string
-        ''')
 
     x_onetep_size_std_grid = Quantity(
         type=np.dtype(np.float64),

--- a/electronicparsers/onetep/parser.py
+++ b/electronicparsers/onetep/parser.py
@@ -417,7 +417,7 @@ class OnetepParser:
                     ),
                 ],
             )
-            sec_method.electronic_model=[sec_em,]
+            sec_method.electrons_representation=[sec_em,]
 
         if self.out_parser.geometry_optimization is not None:
             if self.out_parser.geometry_optimization.single_point is not None:

--- a/electronicparsers/onetep/parser.py
+++ b/electronicparsers/onetep/parser.py
@@ -26,7 +26,7 @@ from nomad.parsing.file_parser import TextParser, Quantity
 from nomad.datamodel.metainfo.simulation.run import (
     Run, Program, TimeRun)
 from nomad.datamodel.metainfo.simulation.method import (
-    Method, DFT, XCFunctional, Functional
+    Method, DFT, XCFunctional, Functional, BasisSet, BasisSetContainer,
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
@@ -119,7 +119,8 @@ class OutParser(TextParser):
                         'rms_gradient',
                         rf'RMS gradient += +({re_f})',
                         dtype=np.float64
-                    )
+                    ),
+
                 ])
             ),
             Quantity(
@@ -193,6 +194,17 @@ class OutParser(TextParser):
                 'date_end',
                 r'Job completed: (\d\d\-\d\d\-\d\d\d\d \d\d:\d\d \(\+\d\d\d\d\))',
                 flatten=False, dtype=str),
+            Quantity(
+                'psinc',
+                r'PSINC grid sizes([\s\S]+)=+',
+                sub_parser=TextParser(quantities=[
+                        Quantity(
+                        'cutoff',
+                        rf'KE cutoff=\s+({re_f})Eh',
+                        dtype=np.float64, unit=ureg.hartree,
+                    ),
+                ])
+            ),
             Quantity(
                 'geometry_optimization',
                 r'Starting ONETEP Geometry Optimisation([\s\S]+?)(?:\- TIMING|\Z)',
@@ -306,7 +318,10 @@ class OnetepParser:
         self.out_parser.logger = self.logger
         self.input_parser.logger = self.logger
 
-    def parse_configuration(self, source):
+    def parse_configuration(self, source: TextParser):
+        '''Generate a system section from `source`.
+        Input:
+        - `source`: information block corresponding to a single point calculation'''
         def parse_system(source):
             cell = source.get('cell', self.input_parser.cell)
             if cell is None:
@@ -389,6 +404,21 @@ class OnetepParser:
                 else:
                     sec_method.dft.xc_functional.contributions.append(Functional(name=xc_functional))
 
+        # Basis set
+        if cutoff := self.out_parser.get('psinc', {}).get('cutoff'):
+            sec_em = BasisSetContainer(
+                type='support functions',
+                scope=['wavefunction'],
+                basis_set=[
+                    BasisSet(
+                        type='psinc functions',
+                        scope=['valence'],
+                        cutoff=cutoff,
+                    ),
+                ],
+            )
+            sec_method.electronic_model=[sec_em,]
+
         if self.out_parser.geometry_optimization is not None:
             if self.out_parser.geometry_optimization.single_point is not None:
                 self.parse_configuration(self.out_parser.geometry_optimization.single_point)
@@ -407,4 +437,3 @@ class OnetepParser:
                     sec_excitation.x_onetep_tddft_excit_energy = excitation[1] * ureg.hartree
                     sec_excitation.x_onetep_tddft_excit_oscill_str = excitation[2]
                     sec_excitation.x_onetep_tddft_excit_lifetime = excitation[3] * ureg.ns
-        # TODO parse md

--- a/electronicparsers/openmx/parser.py
+++ b/electronicparsers/openmx/parser.py
@@ -250,7 +250,7 @@ class OpenmxParser:
 
     def parse_method(self):
         sec_method = self.archive.run[-1].m_create(Method)
-        sec_method.electronic_model = [
+        sec_method.electrons_representation = [
             BasisSetContainer(
                 type='atom-centered orbitals',
                 scope=['wavefunction'],

--- a/electronicparsers/openmx/parser.py
+++ b/electronicparsers/openmx/parser.py
@@ -31,7 +31,8 @@ from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
 )
 from nomad.datamodel.metainfo.simulation.method import (
-    Method, BasisSet, DFT, XCFunctional, Functional, Electronic, Smearing, Scf
+    Method, BasisSet, DFT, XCFunctional, Functional, Electronic, Smearing, Scf,
+    BasisSetContainer,
 )
 from nomad.parsing.file_parser import TextParser, Quantity
 from nomad.datamodel.metainfo.workflow import Workflow, GeometryOptimization, MolecularDynamics
@@ -249,7 +250,18 @@ class OpenmxParser:
 
     def parse_method(self):
         sec_method = self.archive.run[-1].m_create(Method)
-        sec_method.basis_set.append(BasisSet(type='numeric AOs'))
+        sec_method.electronic_model = [
+            BasisSetContainer(
+                type='atom-centered orbitals',
+                scope=['wavefunction'],
+                basis_set=[
+                    BasisSet(
+                        type='numeric AOs',
+                        scope=['full-election'],
+                    )
+                ]
+            )
+        ]
 
         sec_dft = sec_method.m_create(DFT)
         sec_electronic = sec_method.m_create(Electronic)

--- a/electronicparsers/orca/parser.py
+++ b/electronicparsers/orca/parser.py
@@ -619,7 +619,7 @@ class OrcaParser:
                     if bs_index >= len(sec_basis_sets):
                         sec_basis_sets.append(BasisSet(type='gaussians',))
                     setattr(sec_basis_sets[bs_index], metainfo_name, val)
-            sec_method.electronic_model = [
+            sec_method.electrons_representation = [
                 BasisSetContainer(
                     type='atom-centered orbitals',
                     scope=[kind_map],
@@ -628,7 +628,7 @@ class OrcaParser:
             ]
 
         # gaussian basis sets
-        for em in sec_method.electronic_model:
+        for em in sec_method.electrons_representation:
             if 'wavefunction' in em.scope:
                 if basis_set := section.get('basis_set_statistics'):
                     sec_basis_set = BasisSet(type='gaussians',)

--- a/electronicparsers/psi4/parser.py
+++ b/electronicparsers/psi4/parser.py
@@ -27,7 +27,7 @@ from nomad.datamodel.metainfo.simulation.run import Run, Program, TimeRun
 from nomad.datamodel.metainfo.simulation.system import System, Atoms
 from nomad.datamodel.metainfo.simulation.method import (
     Electronic, Method, BasisSet, BasisSetAtomCentered, Scf as ScfMethod, DFT,
-    XCFunctional, Functional)
+    XCFunctional, Functional, BasisSetContainer,)
 from nomad.datamodel.metainfo.simulation.calculation import (
     Calculation, Energy, EnergyEntry, Forces, ForcesEntry, ScfIteration, BandEnergies,
     Multipoles, MultipolesEntry, Charges, ChargesValue)
@@ -598,6 +598,30 @@ class Psi4Parser:
             except Exception:
                 pass
 
+    def _parse_basis(self, source: TextParser) -> list[BasisSet]:
+        '''Produce a list of the gaussian basis sets.'''
+        if source is None:
+            return []
+        atoms: list[BasisSetAtomCentered] = []
+        for entry in source.get('basis_set', []):
+            atom = BasisSetAtomCentered()
+            atom.name = entry.get('Basis Set', '').strip('(').strip(')')
+            atom.n_basis_functions = int(entry.get('Number of basis function', 0))
+            atom.x_psi4_n_shells = int(entry.get('Number of shells', 0))
+            atom.x_psi4_max_angular_momentum = int(entry.get('Max angular momentum', 0))
+            atom.x_psi4_n_cartesian_functions = int(entry.get('Number of Cartesian functions', 0))
+            atom.x_psi4_blend = entry.get('Blend')
+            atom.x_psi4_spherical_harmonics = entry.get('Spherical Harmonics?') == 'false'
+            atoms.append(atom)
+
+        return [
+            BasisSet(
+                type='gaussians',
+                scope=['full-electron'],
+                atom_centered=atoms,
+            ),
+        ]
+
     def parse_method(self, source):
         method = self.archive.run[-1].m_create(Method)
         if self._method is not None:
@@ -609,26 +633,18 @@ class Psi4Parser:
                     method.x_psi4_parameters = {
                         key: val for key, val in source.parameters.get('key_value', [])}
 
-        def parse_basis(source):
-            if source is None:
-                return
-            basis_set = method.m_create(BasisSet)
-            # TODO is this always the case?
-            basis_set.type = 'Gaussians'
-            for entry in source.get('basis_set', []):
-                atom = basis_set.m_create(BasisSetAtomCentered)
-                atom.name = entry.get('Basis Set', '').strip('(').strip(')')
-                atom.n_basis_functions = int(entry.get('Number of basis function', 0))
-                atom.x_psi4_n_shells = int(entry.get('Number of shells', 0))
-                atom.x_psi4_max_angular_momentum = int(entry.get('Max angular momentum', 0))
-                atom.x_psi4_n_cartesian_functions = int(entry.get('Number of Cartesian functions', 0))
-                atom.x_psi4_blend = entry.get('Blend')
-                atom.x_psi4_spherical_harmonics = entry.get('Spherical Harmonics?') == 'false'
-
-        # basis set
-        parse_basis(source.basis)
+        # Basis set
+        basis_sets = self._parse_basis(source.basis)
         for basis in source.get('auxiliary_basis', []):
-            parse_basis(basis)
+            basis_sets += self._parse_basis(basis)
+        if len(basis_sets) > 0:
+            method.electronic_model = [
+                BasisSetContainer(
+                    type='atom-centered orbitals',
+                    scope=['wavefunction'],
+                    basis_set=basis_sets,
+                ),
+            ]
 
         if source.jk_matrices is not None:
             method.x_psi4_jk_matrices_parameters = source.jk_matrices.get('parameters', (None, None))[1]

--- a/electronicparsers/psi4/parser.py
+++ b/electronicparsers/psi4/parser.py
@@ -638,7 +638,7 @@ class Psi4Parser:
         for basis in source.get('auxiliary_basis', []):
             basis_sets += self._parse_basis(basis)
         if len(basis_sets) > 0:
-            method.electronic_model = [
+            method.electrons_representation = [
                 BasisSetContainer(
                     type='atom-centered orbitals',
                     scope=['wavefunction'],

--- a/electronicparsers/qball/parser.py
+++ b/electronicparsers/qball/parser.py
@@ -27,7 +27,7 @@ import logging
 from nomad.units import ureg
 from nomad.datamodel.metainfo.simulation.run import Run, Program, TimeRun
 from nomad.datamodel.metainfo.simulation.system import System, Atoms
-from nomad.datamodel.metainfo.simulation.method import Method, BasisSet
+from nomad.datamodel.metainfo.simulation.method import Method, BasisSet, BasisSetContainer
 from nomad.datamodel.metainfo.simulation.calculation import Calculation, Forces, ForcesEntry
 from nomad.parsing.file_parser import Quantity, TextParser
 
@@ -88,11 +88,21 @@ class QBallParser:
         # method
         method = run.m_create(Method)
         # TODO add dft functionals
-        if "plane waves" not in contents:
-            logger.error("Qball Error: Not a plane wave dft")
+        if "plane waves" in contents:
+            method.electronic_model = [
+                BasisSetContainer(
+                    type="plane waves",
+                    scope=['wavefunction'],
+                    basis_set=[
+                        BasisSet(
+                            type="plane waves",
+                            scope=['valence'],
+                        )
+                    ]
+                )
+            ]
         else:
-            basis_set = method.m_create(BasisSet)
-            basis_set.type = "plane waves"
+            logger.error("Qball Error: Not a plane wave dft")
 
         element_tree = ElementTree.fromstring(contents)
 

--- a/electronicparsers/qball/parser.py
+++ b/electronicparsers/qball/parser.py
@@ -89,7 +89,7 @@ class QBallParser:
         method = run.m_create(Method)
         # TODO add dft functionals
         if "plane waves" in contents:
-            method.electronic_model = [
+            method.electrons_representation = [
                 BasisSetContainer(
                     type="plane waves",
                     scope=['wavefunction'],

--- a/electronicparsers/quantumespresso/parser.py
+++ b/electronicparsers/quantumespresso/parser.py
@@ -2635,7 +2635,7 @@ class QuantumEspressoParser:
         for scope in ['wavefunction', 'density']:
             cutoff = run.get_header('%s_cutoff' % scope)
             if cutoff is not None:
-                sec_method.electronic_model.append(
+                sec_method.electrons_representation.append(
                     BasisSetContainer(
                         type='plane waves',
                         scope=[scope],

--- a/electronicparsers/quantumespresso/parser.py
+++ b/electronicparsers/quantumespresso/parser.py
@@ -27,7 +27,7 @@ from nomad.parsing.file_parser.text_parser import TextParser, Quantity, DataText
 from nomad.datamodel.metainfo.simulation.run import Run, Program, TimeRun
 from nomad.datamodel.metainfo.simulation.method import (
     Electronic, Method, DFT, Smearing, XCFunctional, Functional, BasisSet,
-    BasisSetCellDependent, AtomParameters, KMesh
+    BasisSetContainer, AtomParameters, KMesh
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
@@ -2631,15 +2631,23 @@ class QuantumEspressoParser:
             sec_method.x_qe_starting_charge = initial_charge[0]
             sec_method.x_qe_starting_charge_renormalized = initial_charge[1]
 
-        for name in ['wavefunction', 'density']:
-            cutoff = run.get_header('%s_cutoff' % name)
-            if cutoff is None:
-                continue
-            sec_basis_set = sec_method.m_create(BasisSet)
-            sec_basis_set.type = 'plane waves'
-            sec_basis_set.kind = name
-            sec_basis_set.cell_dependent.append(BasisSetCellDependent(
-                planewave_cutoff=cutoff, kind='plane_waves', name='PW_%.1f' % cutoff.magnitude))
+        # basis set
+        for scope in ['wavefunction', 'density']:
+            cutoff = run.get_header('%s_cutoff' % scope)
+            if cutoff is not None:
+                sec_method.electronic_model.append(
+                    BasisSetContainer(
+                        type='plane waves',
+                        scope=[scope],
+                        basis_set = [
+                            BasisSet(
+                                type='plane waves',
+                                scope=['valence'],
+                                cutoff=cutoff,
+                            )
+                        ]
+                    )
+                )
 
         pseudopotential = run.get_header('pseudopotential', [])
 

--- a/electronicparsers/siesta/parser.py
+++ b/electronicparsers/siesta/parser.py
@@ -356,7 +356,7 @@ class SiestaParser:
                 sec_method.dft.xc_functional.hybrid.append(Functional(name=xc_functional))
             else:
                 sec_method.dft.xc_functional.contributions.append(Functional(name=xc_functional))
-        sec_method.electronic_model = [
+        sec_method.electrons_representation = [
             BasisSetContainer(
                 type='atom-centered orbitals',
                 scope=['wavefunction'],

--- a/electronicparsers/siesta/parser.py
+++ b/electronicparsers/siesta/parser.py
@@ -27,7 +27,7 @@ from nomad.datamodel.metainfo.simulation.run import (
     Run, Program, TimeRun
 )
 from nomad.datamodel.metainfo.simulation.method import (
-    Method, DFT, XCFunctional, Functional, BasisSet
+    Method, DFT, XCFunctional, Functional, BasisSet, BasisSetContainer,
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
@@ -356,8 +356,18 @@ class SiestaParser:
                 sec_method.dft.xc_functional.hybrid.append(Functional(name=xc_functional))
             else:
                 sec_method.dft.xc_functional.contributions.append(Functional(name=xc_functional))
-        sec_basis_set = sec_method.m_create(BasisSet)
-        sec_basis_set.type = 'numeric AOs'
+        sec_method.electronic_model = [
+            BasisSetContainer(
+                type='atom-centered orbitals',
+                scope=['wavefunction'],
+                basis_set=[
+                    BasisSet(
+                        type='numeric AOs',
+                        scope=['full-election'],
+                    )
+                ]
+            )
+        ]
         # parse atomic basis info
 
         def parse_system(source):

--- a/electronicparsers/turbomole/parser.py
+++ b/electronicparsers/turbomole/parser.py
@@ -1086,7 +1086,7 @@ class TurbomoleParser:
                     scope=[scope],
                     basis_set=[bs],
                 )
-                sec_method.electronic_model.append(em)
+                sec_method.electrons_representation.append(em)
 
         # XC Functionals
         sec_xc_functional = sec_dft.m_create(XCFunctional)

--- a/electronicparsers/turbomole/parser.py
+++ b/electronicparsers/turbomole/parser.py
@@ -1082,7 +1082,7 @@ class TurbomoleParser:
                         ac.n_basis_functions = atom[3]
                     bs.atom_centered.append(ac)
                 em = BasisSetContainer(
-                    type='atom-centered',
+                    type='atom-centered orbitals',
                     scope=[scope],
                     basis_set=[bs],
                 )

--- a/electronicparsers/utils/utils.py
+++ b/electronicparsers/utils/utils.py
@@ -123,10 +123,10 @@ class BeyondDFTWorkflowsParser:
         # Method
         method_gw = extract_section(gw_archive, 'run/method/gw')
         method_xcfunctional = extract_section(self.archive, 'run/method/dft/xc_functional')
-        method_basisset = extract_section(self.archive, 'run/method/electronic_model')
+        method_basisset = extract_section(self.archive, 'run/method/electrons_representation')
         workflow.method.gw_method_ref = method_gw
         workflow.method.starting_point = method_xcfunctional
-        workflow.method.electronic_model = method_basisset
+        workflow.method.electrons_representation = method_basisset
 
         # Inputs and Outputs
         input_structure = extract_section(self.archive, 'run/system')

--- a/electronicparsers/utils/utils.py
+++ b/electronicparsers/utils/utils.py
@@ -123,10 +123,10 @@ class BeyondDFTWorkflowsParser:
         # Method
         method_gw = extract_section(gw_archive, 'run/method/gw')
         method_xcfunctional = extract_section(self.archive, 'run/method/dft/xc_functional')
-        method_basisset = extract_section(self.archive, 'run/method/basis_set')
+        method_basisset = extract_section(self.archive, 'run/method/electronic_model')
         workflow.method.gw_method_ref = method_gw
         workflow.method.starting_point = method_xcfunctional
-        workflow.method.basis_set = method_basisset
+        workflow.method.electronic_model = method_basisset
 
         # Inputs and Outputs
         input_structure = extract_section(self.archive, 'run/system')

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -1378,7 +1378,7 @@ class VASPParser():
             atom_counts[element[i]] += 1
         sec_method.x_vasp_atom_kind_refs = sec_method.atom_parameters
 
-        sec_method.electronic_model = [
+        sec_method.electrons_representation = [
             BasisSetContainer(
                 type='plane waves',
                 scope=['wavefunction'],

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -1376,8 +1376,13 @@ class VASPParser():
             atom_counts[element[i]] += 1
         sec_method.x_vasp_atom_kind_refs = sec_method.atom_parameters
 
-        sec_basis_set = sec_method.m_create(BasisSetContainer)
-        sec_basis_set.basis_set = self.parser.get_valence_basis_set()
+        sec_method.electronic_model = [
+            BasisSetContainer(
+                type='plane waves',
+                scope=['wavefunction'],
+            )
+        ]
+        sec_method.electronic_model[0].basis_set = self.parser.get_valence_basis_set()
 
         sec_xc_functional = sec_dft.m_create(XCFunctional)
         if self.parser.incar.get('LHFCALC', False):

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -611,9 +611,9 @@ class OutcarContentParser(ContentParser):
             sec_basis.type = 'plane waves'
             sec_basis.cutoff = cutoff_value * ureg.eV  # based on examples
             if tag == 'ENCUT':
-                    sec_basis.scope = 'valence'
+                    sec_basis.scope = ['valence']
             elif tag == 'ENAUG':
-                sec_basis.scope = 'augmentation'
+                sec_basis.scope = ['augmentation']
             # TODO: add grid spacing (NGX, NGY, NGZ)?
             electron_model.append(sec_basis)
         return electron_model
@@ -1113,9 +1113,9 @@ class RunContentParser(ContentParser):
                 sec_basis.type = 'plane waves'
                 sec_basis.cutoff = cutoff_value * ureg.eV  # based on examples
                 if tag == 'ENMAX':
-                    sec_basis.scope = 'valence'
+                    sec_basis.scope = ['valence']
                 elif tag == 'ENAUG':
-                    sec_basis.scope = 'augmentation'
+                    sec_basis.scope = ['augmentation']
                 # TODO: add grid spacing (NGX, NGY, NGZ)?
                 electron_model.append(sec_basis)
         return electron_model
@@ -1377,7 +1377,7 @@ class VASPParser():
         sec_method.x_vasp_atom_kind_refs = sec_method.atom_parameters
 
         sec_basis_set = sec_method.m_create(BasisSetContainer)
-        sec_basis_set.basis_set.append(self.parser.get_valence_basis_set())
+        sec_basis_set.basis_set = self.parser.get_valence_basis_set()
 
         sec_xc_functional = sec_dft.m_create(XCFunctional)
         if self.parser.incar.get('LHFCALC', False):

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -604,19 +604,20 @@ class OutcarContentParser(ContentParser):
         return dict(cell=cell, positions=positions, selective=selective, nose=nose)
 
     def get_valence_basis_set(self) -> list[BasisSet]:
-        electron_model: list[BasisSet] = []
+        sec_bases: list[BasisSet] = []
         for tag in ('ENCUT', 'ENAUG'):
             cutoff_value = self.parser.get('parameters').get(tag)
-            sec_basis = BasisSet()
-            sec_basis.type = 'plane waves'
-            sec_basis.cutoff = cutoff_value * ureg.eV  # based on examples
+            sec_basis = BasisSet(
+                type='plane waves',
+                cutoff=cutoff_value * ureg.eV,  # based on examples
+            )
             if tag == 'ENCUT':
-                    sec_basis.scope = ['valence']
+                sec_basis.scope = ['valence']
             elif tag == 'ENAUG':
                 sec_basis.scope = ['augmentation']
             # TODO: add grid spacing (NGX, NGY, NGZ)?
-            electron_model.append(sec_basis)
-        return electron_model
+            sec_bases.append(sec_basis)
+        return sec_bases
 
     def get_energies(self, n_calc, n_scf):
         energies = dict()
@@ -1104,21 +1105,22 @@ class RunContentParser(ContentParser):
 
     def get_valence_basis_set(self) -> list[BasisSet]:
         path = '/modeling[0]/parameters/separator[@name="electronic"]'
-        electron_model: list[BasisSet] = []
+        sec_bases: list[BasisSet] = []
         for tag in ('ENMAX', 'ENAUG'):
             cutoff_path = f'{path}/i[@name="{tag}"]'
             cutoff_value = self._get_key_values(cutoff_path).get(tag)
             if cutoff_value is not None:
-                sec_basis = BasisSet()
-                sec_basis.type = 'plane waves'
-                sec_basis.cutoff = cutoff_value * ureg.eV  # based on examples
+                sec_basis = BasisSet(
+                    type='plane waves',
+                    cutoff=cutoff_value * ureg.eV,  # based on examples
+                )
                 if tag == 'ENMAX':
                     sec_basis.scope = ['valence']
                 elif tag == 'ENAUG':
                     sec_basis.scope = ['augmentation']
                 # TODO: add grid spacing (NGX, NGY, NGZ)?
-                electron_model.append(sec_basis)
-        return electron_model
+                sec_bases.append(sec_basis)
+        return sec_bases
 
     def get_n_scf(self, n_calc):
         if self._n_scf is None:
@@ -1380,9 +1382,9 @@ class VASPParser():
             BasisSetContainer(
                 type='plane waves',
                 scope=['wavefunction'],
+                basis_set=self.parser.get_valence_basis_set(),
             )
         ]
-        sec_method.electronic_model[0].basis_set = self.parser.get_valence_basis_set()
 
         sec_xc_functional = sec_dft.m_create(XCFunctional)
         if self.parser.incar.get('LHFCALC', False):

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -43,7 +43,7 @@ from nomad.parsing.file_parser import FileParser
 from nomad.parsing.file_parser.text_parser import TextParser, Quantity
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
-    Method, BasisSet, BasisSetCellDependent, DFT, HubbardKanamoriModel, AtomParameters,
+    Method, BasisSet, BasisSetContainer, DFT, HubbardKanamoriModel, AtomParameters,
     XCFunctional, Functional, Electronic, Scf, KMesh, GW, FrequencyMesh, Pseudopotential,
 )
 from nomad.datamodel.metainfo.simulation.system import (
@@ -603,6 +603,21 @@ class OutcarContentParser(ContentParser):
 
         return dict(cell=cell, positions=positions, selective=selective, nose=nose)
 
+    def get_valence_basis_set(self) -> list[BasisSet]:
+        electron_model: list[BasisSet] = []
+        for tag in ('ENCUT', 'ENAUG'):
+            cutoff_value = self.parser.get('parameters').get(tag)
+            sec_basis = BasisSet()
+            sec_basis.type = 'plane waves'
+            sec_basis.cutoff = cutoff_value * ureg.eV  # based on examples
+            if tag == 'ENCUT':
+                    sec_basis.scope = 'valence'
+            elif tag == 'ENAUG':
+                sec_basis.scope = 'augmentation'
+            # TODO: add grid spacing (NGX, NGY, NGZ)?
+            electron_model.append(sec_basis)
+        return electron_model
+
     def get_energies(self, n_calc, n_scf):
         energies = dict()
         multiplier = 1.0
@@ -1087,6 +1102,24 @@ class RunContentParser(ContentParser):
         potcar_file = os.path.join(self.parser.maindir, 'POTCAR.stripped')
         return super().get_pseudopotential(potcar_file)
 
+    def get_valence_basis_set(self) -> list[BasisSet]:
+        path = '/modeling[0]/parameters/separator[@name="electronic"]'
+        electron_model: list[BasisSet] = []
+        for tag in ('ENMAX', 'ENAUG'):
+            cutoff_path = f'{path}/i[@name="{tag}"]'
+            cutoff_value = self._get_key_values(cutoff_path).get(tag)
+            if cutoff_value is not None:
+                sec_basis = BasisSet()
+                sec_basis.type = 'plane waves'
+                sec_basis.cutoff = cutoff_value * ureg.eV  # based on examples
+                if tag == 'ENMAX':
+                    sec_basis.scope = 'valence'
+                elif tag == 'ENAUG':
+                    sec_basis.scope = 'augmentation'
+                # TODO: add grid spacing (NGX, NGY, NGZ)?
+                electron_model.append(sec_basis)
+        return electron_model
+
     def get_n_scf(self, n_calc):
         if self._n_scf is None:
             self._n_scf = [None] * self.n_calculations
@@ -1343,13 +1376,8 @@ class VASPParser():
             atom_counts[element[i]] += 1
         sec_method.x_vasp_atom_kind_refs = sec_method.atom_parameters
 
-        prec = 1.3 if 'acc' in self.parser.incar.get('PREC', '') else 1.0
-        sec_basis = sec_method.m_create(BasisSet)
-        sec_basis.type = 'plane waves'
-        sec_basis_set_cell_dependent = sec_basis.m_create(BasisSetCellDependent)
-        sec_basis_set_cell_dependent.kind = 'plane waves'
-        sec_basis_set_cell_dependent.planewave_cutoff = self.parser.incar.get(
-            'ENMAX', self.parser.incar.get('ENCUT', 0.0)) * prec * ureg.eV
+        sec_basis_set = sec_method.m_create(BasisSetContainer)
+        sec_basis_set.basis_set.append(self.parser.get_valence_basis_set())
 
         sec_xc_functional = sec_dft.m_create(XCFunctional)
         if self.parser.incar.get('LHFCALC', False):

--- a/electronicparsers/wien2k/metainfo/wien2k.py
+++ b/electronicparsers/wien2k/metainfo/wien2k.py
@@ -637,21 +637,6 @@ class Method(simulation.method.Method):
         optional print switch, in in0
         ''')
 
-    x_wien2k_wf_switch = Quantity(
-        type=str,
-        shape=[],
-        description='''
-        wave function switch between WFFIL, SUPWF, WPPRI
-        ''')
-
-    x_wien2k_rkmax = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        description='''
-        RmtKmax - determines matrix size (convergence), where Kmax is the plane wave cut-
-        off, Rmt is the smallest of all atomic sphere radii
-        ''')
-
     x_wien2k_in2_switch = Quantity(
         type=str,
         shape=[],

--- a/electronicparsers/wien2k/parser.py
+++ b/electronicparsers/wien2k/parser.py
@@ -819,7 +819,7 @@ class Wien2kParser:
                 em.basis_set.append(
                     BasisSet(
                         scope = ['intersitial', 'valence'],
-                        type = 'plane wave',
+                        type = 'plane waves',
                         cutoff_fractional=source.get('rkmax', None),
                     )
                 )

--- a/electronicparsers/wien2k/parser.py
+++ b/electronicparsers/wien2k/parser.py
@@ -814,16 +814,16 @@ class Wien2kParser:
         if self.in1_parser._results:
             type_mapping = ('LAPW', 'APW', 'HDLO', 'LO')
             source: dict(str, Any) = self.in1_parser._results
-            em = BasisSetContainer(scope='wavefunction')
+            em = BasisSetContainer(scope=['wavefunction'])
             em.basis_set.append(
                 BasisSet(
-                    scope = 'intersitial',
+                    scope = ['intersitial', 'valence'],
                     type = 'plane wave',
                     cutoff_fractional=source.get('rkmax', None),
                 )
             )
             for mt in source.get('species', []):
-                bs = BasisSet(scope='muffin-tin',
+                bs = BasisSet(scope=['muffin-tin', 'full-electron'],
                               spherical_harmonics_cutoff=source.get('lmax'))
                 for l in range(source.get('lmax', -1) + 1):
                     orbital = OrbitalAPW()

--- a/electronicparsers/wien2k/parser.py
+++ b/electronicparsers/wien2k/parser.py
@@ -810,46 +810,47 @@ class Wien2kParser:
 
         # basis
         #sec_method.basis_set.append(BasisSet(type='(L)APW+lo'))
-        self.in1_parser.parse()
-        if self.in1_parser._results:
-            type_mapping = ('LAPW', 'APW', 'HDLO', 'LO')
-            source: dict(str, Any) = self.in1_parser._results
-            em = BasisSetContainer(scope=['wavefunction'])
-            em.basis_set.append(
-                BasisSet(
-                    scope = ['intersitial', 'valence'],
-                    type = 'plane wave',
-                    cutoff_fractional=source.get('rkmax', None),
+        if self.in1_parser.mainfile:
+            self.in1_parser.parse()
+            if self.in1_parser._results:
+                type_mapping = ('LAPW', 'APW', 'HDLO', 'LO')
+                source: dict(str, Any) = self.in1_parser._results
+                em = BasisSetContainer(scope=['wavefunction'])
+                em.basis_set.append(
+                    BasisSet(
+                        scope = ['intersitial', 'valence'],
+                        type = 'plane wave',
+                        cutoff_fractional=source.get('rkmax', None),
+                    )
                 )
-            )
-            for mt in source.get('species', []):
-                bs = BasisSet(scope=['muffin-tin', 'full-electron'],
-                              spherical_harmonics_cutoff=source.get('lmax'))
-                for l in range(source.get('lmax', -1) + 1):
-                    orbital = OrbitalAPW()
-                    orbital.l_quantum_number = l
-                    orbital.core_level = False
-                    e_param = mt.get('e_param', source.get('e_ref', .5) - .2)  # TODO: check for +.2 case
-                    update = False
-                    apw_type = mt.get('type')
-                    last_orbital_type = None
-                    for orb in mt['orbital']:
-                        if l == orb['l']:
-                            e_param = orb.get('e_param', e_param)
-                            update = False if not orb.get('e_diff', 0) else True
-                            apw_type = orb.get('type', apw_type)
-                            if last_orbital_type == apw_type:
-                                orbital.energy_parameter = e_param
-                                orbital.update = update
-                                orbital.type = type_mapping[3]
-                                continue
-                            last_orbital_type = apw_type
-                    orbital.energy_parameter = e_param
-                    orbital.update = update
-                    orbital.type = type_mapping[apw_type]
-                    bs.orbital.append(orbital)
-                em.basis_set.append(bs)
-            sec_method.electronic_model.append(em)
+                for mt in source.get('species', []):
+                    bs = BasisSet(scope=['muffin-tin', 'full-electron'],
+                                spherical_harmonics_cutoff=source.get('lmax'))
+                    for l in range(source.get('lmax', -1) + 1):
+                        orbital = OrbitalAPW()
+                        orbital.l_quantum_number = l
+                        orbital.core_level = False
+                        e_param = mt.get('e_param', source.get('e_ref', .5) - .2)  # TODO: check for +.2 case
+                        update = False
+                        apw_type = mt.get('type')
+                        last_orbital_type = None
+                        for orb in mt['orbital']:
+                            if l == orb['l']:
+                                e_param = orb.get('e_param', e_param)
+                                update = False if not orb.get('e_diff', 0) else True
+                                apw_type = orb.get('type', apw_type)
+                                if last_orbital_type == apw_type:
+                                    orbital.energy_parameter = e_param
+                                    orbital.update = update
+                                    orbital.type = type_mapping[3]
+                                    continue
+                                last_orbital_type = apw_type
+                        orbital.energy_parameter = e_param
+                        orbital.update = update
+                        orbital.type = type_mapping[apw_type]
+                        bs.orbital.append(orbital)
+                    em.basis_set.append(bs)
+                sec_method.electronic_model.append(em)
 
     def parse(self, filepath, archive, logger):
         self.filepath = os.path.abspath(filepath)

--- a/electronicparsers/wien2k/parser.py
+++ b/electronicparsers/wien2k/parser.py
@@ -820,12 +820,12 @@ class Wien2kParser:
                     BasisSet(
                         scope = ['intersitial', 'valence'],
                         type = 'plane waves',
-                        cutoff_fractional=source.get('rkmax', None),
+                        cutoff_fractional=source.get('rkmax'),
                     )
                 )
                 for mt in source.get('species', []):
                     bs = BasisSet(scope=['muffin-tin', 'full-electron'],
-                                spherical_harmonics_cutoff=source.get('lmax'))
+                        spherical_harmonics_cutoff=source.get('lmax'))
                     for l in range(source.get('lmax', -1) + 1):
                         orbital = OrbitalAPW()
                         orbital.l_quantum_number = l

--- a/electronicparsers/wien2k/parser.py
+++ b/electronicparsers/wien2k/parser.py
@@ -850,7 +850,7 @@ class Wien2kParser:
                         orbital.type = type_mapping[apw_type]
                         bs.orbital.append(orbital)
                     em.basis_set.append(bs)
-                sec_method.electronic_model.append(em)
+                sec_method.electrons_representation.append(em)
 
     def parse(self, filepath, archive, logger):
         self.filepath = os.path.abspath(filepath)

--- a/electronicparsers/wien2k/parser.py
+++ b/electronicparsers/wien2k/parser.py
@@ -25,10 +25,12 @@ from ase.io import read as ioread
 from ase import Atoms
 
 from nomad.units import ureg
+from nomad.parsing.file_parser.file_parser import FileParser
 from nomad.parsing.file_parser import TextParser, Quantity
 from nomad.datamodel.metainfo.simulation.run import Run, Program, TimeRun
 from nomad.datamodel.metainfo.simulation.method import (
-    Electronic, Method, DFT, Smearing, XCFunctional, Functional, KMesh, BasisSet
+    Electronic, Method, DFT, Smearing, XCFunctional, Functional, KMesh, BasisSet,
+    BasisSetContainer, OrbitalAPW
 )
 from nomad.datamodel.metainfo.simulation.system import (
     System, Atoms
@@ -39,6 +41,7 @@ from nomad.datamodel.metainfo.simulation.calculation import (
 )
 from nomad.datamodel.metainfo.workflow import Workflow
 from .metainfo.wien2k import x_wien2k_section_equiv_atoms
+from typing import Any
 
 
 class In0Parser(TextParser):
@@ -53,14 +56,50 @@ class In0Parser(TextParser):
             Quantity('fft', r'FFT[\s\S]+?(\d+\s+\d+\s+\d+\s+[\d\.]+)')]
 
 
-class In1Parser(TextParser):
-    def __init__(self):
-        super().__init__()
+class In1Parser(FileParser):
+    def __init__(self, mainfile=None, logger=None, open=None):
+        super().__init__(mainfile, logger=logger, open=open)
 
-    def init_quantities(self):
-        self._quantities = [
-            Quantity('wf_switch', r'(WFFIL|WFPRI|ENFIL|SUPWF)'),
-            Quantity('rkmax', r'([\d\.]+\s*\d+\s*\d+).+K\-MAX', dtype=np.float64)]
+    def parse(self):
+        self._results = {'species': []}
+        num_orbitals: int = 0
+        with self.mainfile_obj as f:
+            for line_id, line in enumerate(f):
+                if line_id == 0:
+                    line = line.strip().split()
+                    self._results['calc_mode'] = line[0]
+                    if re.match(r'EF', line[1]):
+                        self._results['e_ref'] = float(line[1].split('=')[1])
+                elif line_id == 1:
+                    line = line.strip().split()
+                    for tag, val in zip(['rkmax', 'lmax', 'lvnsmax'], line):
+                        try:
+                            self._results[tag] = int(val)
+                        except ValueError:
+                            self._results[tag] = float(val)
+                elif re.search(r'K-VECTORS', line):
+                    continue
+                # further specify the species setup
+                elif num_orbitals > 0:
+                    line = line.strip().split()
+                    orbital_settings = {}
+                    for tag, val in zip(['l', 'e_param', 'e_diff', 'diff_search', 'type'], line[:5]):
+                        for converter in (int, float, lambda x: x):
+                            try:
+                                orbital_settings[tag] = converter(val)
+                                break
+                            except ValueError:
+                                pass
+                    self._results['species'][-1]['orbital'].append(orbital_settings)
+                    num_orbitals -= 1
+                # add a new species setup
+                elif num_orbitals == 0:
+                    species_settings = {'orbital': []}
+                    line = line.strip().split()
+                    species_settings['e_param'] = float(line[0])
+                    species_settings['type'] = int(line[2])
+                    self._results['species'].append(species_settings)
+                    num_orbitals = int(line[1])
 
 
 class StructParser(TextParser):
@@ -733,9 +772,6 @@ class Wien2kParser:
         if in1_file is None:
             in1_file = self.get_wien2k_file('in1c')
         self.in1_parser.mainfile = in1_file
-        for key, val in self.in1_parser.items():
-            if val is not None:
-                setattr(sec_method, 'x_wien2k_%s' % key, val)
 
         # read integration data from in2 file
         in2_file = self.get_wien2k_file('1n2')
@@ -773,7 +809,47 @@ class Wien2kParser:
             sec_k_mesh.weights = kpoints[1]
 
         # basis
-        sec_method.basis_set.append(BasisSet(type='(L)APW+lo'))
+        #sec_method.basis_set.append(BasisSet(type='(L)APW+lo'))
+        self.in1_parser.parse()
+        if self.in1_parser._results:
+            type_mapping = ('LAPW', 'APW', 'HDLO', 'LO')
+            source: dict(str, Any) = self.in1_parser._results
+            em = BasisSetContainer(scope='wavefunction')
+            em.basis_set.append(
+                BasisSet(
+                    scope = 'intersitial',
+                    type = 'plane wave',
+                    cutoff_fractional=source.get('rkmax', None),
+                )
+            )
+            for mt in source.get('species', []):
+                bs = BasisSet(scope='muffin-tin',
+                              spherical_harmonics_cutoff=source.get('lmax'))
+                for l in range(source.get('lmax', -1) + 1):
+                    orbital = OrbitalAPW()
+                    orbital.l_quantum_number = l
+                    orbital.core_level = False
+                    e_param = mt.get('e_param', source.get('e_ref', .5) - .2)  # TODO: check for +.2 case
+                    update = False
+                    apw_type = mt.get('type')
+                    last_orbital_type = None
+                    for orb in mt['orbital']:
+                        if l == orb['l']:
+                            e_param = orb.get('e_param', e_param)
+                            update = False if not orb.get('e_diff', 0) else True
+                            apw_type = orb.get('type', apw_type)
+                            if last_orbital_type == apw_type:
+                                orbital.energy_parameter = e_param
+                                orbital.update = update
+                                orbital.type = type_mapping[3]
+                                continue
+                            last_orbital_type = apw_type
+                    orbital.energy_parameter = e_param
+                    orbital.update = update
+                    orbital.type = type_mapping[apw_type]
+                    bs.orbital.append(orbital)
+                em.basis_set.append(bs)
+            sec_method.electronic_model.append(em)
 
     def parse(self, filepath, archive, logger):
         self.filepath = os.path.abspath(filepath)

--- a/tests/data/exciting/species_example/C.xml
+++ b/tests/data/exciting/species_example/C.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spdb xsi:noNamespaceSchemaLocation="../../xml/species.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <sp chemicalSymbol="C" name="carbon" z="-6.00000" mass="21894.16673">
+    <muffinTin rmin="0.100000E-04" radius="1.4500" rinf="21.0932" radialmeshPoints="250"/>
+    <atomicState n="1" l="0" kappa="1" occ="2.00000" core="true"/>
+    <atomicState n="2" l="0" kappa="1" occ="2.00000" core="false"/>
+    <atomicState n="2" l="1" kappa="1" occ="1.00000" core="false"/>
+    <atomicState n="2" l="1" kappa="2" occ="1.00000" core="false"/>
+    <basis>
+      <default type="lapw" trialEnergy="0.1500" searchE="false"/>
+      <custom l="0" type="apw+lo" trialEnergy="0.1500" searchE="true"/>
+      <custom l="1" type="apw+lo" trialEnergy="0.1500" searchE="true"/>
+    </basis>
+  </sp>
+</spdb>

--- a/tests/data/exciting/species_example/C_scf.xml
+++ b/tests/data/exciting/species_example/C_scf.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spdb xsi:noNamespaceSchemaLocation="../../xml/species.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <sp chemicalSymbol="C" name="carbon" z="-6.00000" mass="21894.16673">
+    <muffinTin rmin="0.100000E-04" radius="1.4500" rinf="21.0932" radialmeshPoints="250"/>
+    <atomicState n="1" l="0" kappa="1" occ="2.00000" core="true"/>
+    <atomicState n="2" l="0" kappa="1" occ="2.00000" core="false"/>
+    <atomicState n="2" l="1" kappa="1" occ="1.00000" core="false"/>
+    <atomicState n="2" l="1" kappa="2" occ="1.00000" core="false"/>
+    <basis>
+      <default>
+        <wf matchingOrder="0" trialEnergy="0.1500" searchE="false"/>
+      </default>
+      <custom l="0">
+        <wf matchingOrder="0" trialEnergy="0.1500" searchE="true"/>
+      </custom>
+      <custom l="1">
+        <wf matchingOrder="0" trialEnergy="0.2725" searchE="true"/>
+      </custom>
+      <lo l="0">
+        <wf matchingOrder="0" trialEnergy="0.1500" searchE="true"/>
+        <wf matchingOrder="1" trialEnergy="0.1500" searchE="true"/>
+      </lo>
+      <lo l="1">
+        <wf matchingOrder="0" trialEnergy="0.2725" searchE="true"/>
+        <wf matchingOrder="1" trialEnergy="0.2725" searchE="true"/>
+      </lo>
+    </basis>
+    <!-- This file was automatically generated-->
+    <!-- Default linearization energies have been replaced by that -->
+    <!-- found using findlinentype='Wigner_Seitz' method -->
+  </sp>
+</spdb>

--- a/tests/data/exciting/species_example/INFO.OUT
+++ b/tests/data/exciting/species_example/INFO.OUT
@@ -1,0 +1,668 @@
+================================================================================
+| EXCITING OXYGEN started                                                      =
+| version hash id: 8a9364ff6352b5f8d84b3315096e1bbae6dafdb4                    =
+|                                                                              =
+| compiler: ifort (IFORT) 2021.3.0 20210609                                    =
+|                                                                              =
+| MPI version using      1 processor(s)                                        =
+| |  using MPI-2 features                                                      =
+|                                                                              =
+| Date (DD-MM-YYYY) : 27-04-2023                                               =
+| Time (hh:mm:ss)   : 12:44:29                                                 =
+|                                                                              =
+| All units are atomic (Hartree, Bohr, etc.)                                   =
+================================================================================
+ 
+********************************************************************************
+* Ground-state run starting from atomic densities                              *
+********************************************************************************
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ Starting initialization                                                      +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 
+ Lattice vectors (cartesian) :
+      0.0000000000      4.1221029535      4.1221029535
+      4.1221029535      0.0000000000      4.1221029535
+      4.1221029535      4.1221029535      0.0000000000
+ 
+ Reciprocal lattice vectors (cartesian) :
+     -0.7621334763      0.7621334763      0.7621334763
+      0.7621334763     -0.7621334763      0.7621334763
+      0.7621334763      0.7621334763     -0.7621334763
+ 
+ Unit cell volume                           :     140.0833435838
+ Brillouin zone volume                      :       1.7707331014
+ 
+ Species :    1 (Si)
+     parameters loaded from                 :    Si.xml
+     name                                   :    silicon
+     nuclear charge                         :     -14.00000000
+     electronic charge                      :      14.00000000
+     atomic mass                            :   51196.73454000
+     muffin-tin radius                      :       2.00000000
+     # of radial points in muffin-tin       :     300
+ 
+     atomic positions (lattice) :
+       1 :   0.00000000  0.00000000  0.00000000
+ 
+ Species :    2 (C)
+     parameters loaded from                 :    C.xml
+     name                                   :    carbon
+     nuclear charge                         :      -6.00000000
+     electronic charge                      :       6.00000000
+     atomic mass                            :   21894.16673000
+     muffin-tin radius                      :       1.45000000
+     # of radial points in muffin-tin       :     250
+ 
+     atomic positions (lattice) :
+       1 :   0.25000000  0.25000000  0.25000000
+ 
+ Total number of atoms per unit cell        :       2
+ 
+ Spin treatment                             :    spin-unpolarised
+ 
+ Number of Bravais lattice symmetries       :      48
+ Number of crystal symmetries               :      24
+ 
+ k-point grid                               :       4    4    4
+ Total number of k-points                   :      10
+ k-point set is reduced with crystal symmetries
+ 
+ R^MT_min * |G+k|_max (rgkmax)              :       6.00000000
+ Species with R^MT_min                      :       2 (C)
+ Maximum |G+k| for APW functions            :       4.13793103
+ Maximum |G| for potential and density      :      10.00000000
+ 
+ G-vector grid sizes                        :      20    20    20
+ Total number of G-vectors                  :    2421
+ 
+ Maximum angular momentum used for
+     APW functions                          :       8
+     computing H and O matrix elements      :       8
+     potential and density                  :       8
+     inner part of muffin-tin               :       2
+ 
+ Total nuclear charge                       :     -20.00000000
+ Total electronic charge                    :      20.00000000
+ Total core charge                          :       6.00000000
+ Total valence charge                       :      14.00000000
+ 
+ Number of empty states                     :      50
+ Total number of valence states             :      58
+ 
+ Maximum Hamiltonian size                   :     187
+ Maximum number of plane-waves              :     176
+ Total number of local-orbitals             :      11
+ 
+ Exchange-correlation type                  :     100
+     libxc; exchange: Perdew, Burke & Ernzerhof; correlation: Perdew, Burke & Ernzerhof (see libxc for references)
+ 
+ Smearing scheme                            :    Gaussian
+ Smearing width                             :       0.00100000
+ 
+ Using multisecant Broyden potential mixing
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ Ending initialization                                                        +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 
+********************************************************************************
+* Groundstate module started                                                   *
+********************************************************************************
+ Output level for this task is set to normal
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ Self-consistent loop started                                                 +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Density and potential initialised from atomic data
+ 
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ SCF iteration number :    1                                                  +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -329.12787070
+ _______________________________________________________________
+ Fermi energy                               :         0.28477102
+ Kinetic energy                             :       328.39995578
+ Coulomb energy                             :      -631.00062845
+ Exchange energy                            :       -25.76597427
+ Correlation energy                         :        -0.76122376
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00047114
+     valence                                :        14.00000000
+     interstitial                           :         3.44707878
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.66198475
+                  atom     2     C          :         4.89093647
+     total charge in muffin-tins            :        16.55292122
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.13633185
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+ Wall time (seconds)                        :         0.70
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ SCF iteration number :    2                                                  +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -328.75935382
+ _______________________________________________________________
+ Fermi energy                               :         0.30858666
+ Kinetic energy                             :       328.57890900
+ Coulomb energy                             :      -630.89793187
+ Exchange energy                            :       -25.67278342
+ Correlation energy                         :        -0.76754753
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00046557
+     valence                                :        14.00000000
+     interstitial                           :         3.57344111
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.83100097
+                  atom     2     C          :         4.59555792
+     total charge in muffin-tins            :        16.42655889
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.08782632
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+ Wall time (seconds)                        :         1.10
+ 
+ RMS change in effective potential (target) :   1.38220      ( 0.100000E-05)
+ Absolute change in total energy   (target) :  0.368517      ( 0.100000E-05)
+ Charge distance                   (target) :  0.335820E-01  ( 0.100000E-04)
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ SCF iteration number :    3                                                  +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -328.54643678
+ _______________________________________________________________
+ Fermi energy                               :         0.31942272
+ Kinetic energy                             :       328.67876282
+ Coulomb energy                             :      -630.82170931
+ Exchange energy                            :       -25.63282698
+ Correlation energy                         :        -0.77066331
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00046423
+     valence                                :        14.00000000
+     interstitial                           :         3.63115467
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.90533379
+                  atom     2     C          :         4.46351153
+     total charge in muffin-tins            :        16.36884533
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.06567747
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+ Wall time (seconds)                        :         1.50
+ 
+ RMS change in effective potential (target) :   1.02061      ( 0.100000E-05)
+ Absolute change in total energy   (target) :  0.212917      ( 0.100000E-05)
+ Charge distance                   (target) :  0.153929E-01  ( 0.100000E-04)
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ SCF iteration number :    4                                                  +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -328.03051227
+ _______________________________________________________________
+ Fermi energy                               :         0.32089693
+ Kinetic energy                             :       328.87088818
+ Coulomb energy                             :      -630.51718729
+ Exchange energy                            :       -25.61337944
+ Correlation energy                         :        -0.77083372
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00046971
+     valence                                :        14.00000000
+     interstitial                           :         3.65041173
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.87650664
+                  atom     2     C          :         4.47308163
+     total charge in muffin-tins            :        16.34958827
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.06272862
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+ Wall time (seconds)                        :         1.89
+ 
+ RMS change in effective potential (target) :  0.609644E-01  ( 0.100000E-05)
+ Absolute change in total energy   (target) :  0.515925      ( 0.100000E-05)
+ Charge distance                   (target) :  0.384396E-02  ( 0.100000E-04)
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ SCF iteration number :    5                                                  +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -328.25142921
+ _______________________________________________________________
+ Fermi energy                               :         0.32654102
+ Kinetic energy                             :       328.78683663
+ Coulomb energy                             :      -630.66592049
+ Exchange energy                            :       -25.59927853
+ Correlation energy                         :        -0.77306682
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00046352
+     valence                                :        14.00000000
+     interstitial                           :         3.68154770
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.94121020
+                  atom     2     C          :         4.37724211
+     total charge in muffin-tins            :        16.31845230
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.04725019
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+ Wall time (seconds)                        :         2.30
+ 
+ RMS change in effective potential (target) :  0.574393E-02  ( 0.100000E-05)
+ Absolute change in total energy   (target) :  0.220917      ( 0.100000E-05)
+ Charge distance                   (target) :  0.117912E-01  ( 0.100000E-04)
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ SCF iteration number :    6                                                  +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -328.11109466
+ _______________________________________________________________
+ Fermi energy                               :         0.32656410
+ Kinetic energy                             :       328.84249914
+ Coulomb energy                             :      -630.58460042
+ Exchange energy                            :       -25.59609842
+ Correlation energy                         :        -0.77289496
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00046618
+     valence                                :        14.00000000
+     interstitial                           :         3.68113206
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.93336186
+                  atom     2     C          :         4.38550608
+     total charge in muffin-tins            :        16.31886794
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.04866659
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+ Wall time (seconds)                        :         2.69
+ 
+ RMS change in effective potential (target) :  0.270470E-02  ( 0.100000E-05)
+ Absolute change in total energy   (target) :  0.140335      ( 0.100000E-05)
+ Charge distance                   (target) :  0.123118E-02  ( 0.100000E-04)
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ SCF iteration number :    7                                                  +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -328.15398753
+ _______________________________________________________________
+ Fermi energy                               :         0.32661972
+ Kinetic energy                             :       328.82766810
+ Coulomb energy                             :      -630.61136691
+ Exchange energy                            :       -25.59735524
+ Correlation energy                         :        -0.77293349
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00046538
+     valence                                :        14.00000000
+     interstitial                           :         3.68107003
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.93555925
+                  atom     2     C          :         4.38337072
+     total charge in muffin-tins            :        16.31892997
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.04843604
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+ Wall time (seconds)                        :         3.08
+ 
+ RMS change in effective potential (target) :  0.690073E-03  ( 0.100000E-05)
+ Absolute change in total energy   (target) :  0.428929E-01  ( 0.100000E-05)
+ Charge distance                   (target) :  0.320738E-03  ( 0.100000E-04)
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ SCF iteration number :    8                                                  +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -328.15366645
+ _______________________________________________________________
+ Fermi energy                               :         0.32661170
+ Kinetic energy                             :       328.82724510
+ Coulomb energy                             :      -630.61066646
+ Exchange energy                            :       -25.59731282
+ Correlation energy                         :        -0.77293227
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00046539
+     valence                                :        14.00000000
+     interstitial                           :         3.68105148
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.93553587
+                  atom     2     C          :         4.38341265
+     total charge in muffin-tins            :        16.31894852
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.04842663
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+ Wall time (seconds)                        :         3.48
+ 
+ RMS change in effective potential (target) :  0.161495E-03  ( 0.100000E-05)
+ Absolute change in total energy   (target) :  0.321081E-03  ( 0.100000E-05)
+ Charge distance                   (target) :  0.112982E-04  ( 0.100000E-04)
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ SCF iteration number :    9                                                  +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -328.15370675
+ _______________________________________________________________
+ Fermi energy                               :         0.32658967
+ Kinetic energy                             :       328.82684807
+ Coulomb energy                             :      -630.61027556
+ Exchange energy                            :       -25.59735445
+ Correlation energy                         :        -0.77292480
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00046539
+     valence                                :        14.00000000
+     interstitial                           :         3.68094438
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.93534666
+                  atom     2     C          :         4.38370896
+     total charge in muffin-tins            :        16.31905562
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.04847285
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+ Wall time (seconds)                        :         3.90
+ 
+ RMS change in effective potential (target) :  0.141340E-04  ( 0.100000E-05)
+ Absolute change in total energy   (target) :  0.402964E-04  ( 0.100000E-05)
+ Charge distance                   (target) :  0.368194E-04  ( 0.100000E-04)
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ SCF iteration number :   10                                                  +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -328.15423646
+ _______________________________________________________________
+ Fermi energy                               :         0.32658886
+ Kinetic energy                             :       328.82702660
+ Coulomb energy                             :      -630.61093740
+ Exchange energy                            :       -25.59740073
+ Correlation energy                         :        -0.77292493
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00046538
+     valence                                :        14.00000000
+     interstitial                           :         3.68093835
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.93534249
+                  atom     2     C          :         4.38371916
+     total charge in muffin-tins            :        16.31906165
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.04847494
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+ Wall time (seconds)                        :         4.30
+ 
+ RMS change in effective potential (target) :  0.125033E-04  ( 0.100000E-05)
+ Absolute change in total energy   (target) :  0.529714E-03  ( 0.100000E-05)
+ Charge distance                   (target) :  0.387895E-05  ( 0.100000E-04)
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ SCF iteration number :   11                                                  +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -328.15405427
+ _______________________________________________________________
+ Fermi energy                               :         0.32658910
+ Kinetic energy                             :       328.82696019
+ Coulomb energy                             :      -630.61070556
+ Exchange energy                            :       -25.59738393
+ Correlation energy                         :        -0.77292497
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00046538
+     valence                                :        14.00000000
+     interstitial                           :         3.68094076
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.93534739
+                  atom     2     C          :         4.38371184
+     total charge in muffin-tins            :        16.31905924
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.04847358
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+ Wall time (seconds)                        :         4.70
+ 
+ RMS change in effective potential (target) :  0.109304E-05  ( 0.100000E-05)
+ Absolute change in total energy   (target) :  0.182194E-03  ( 0.100000E-05)
+ Charge distance                   (target) :  0.179592E-05  ( 0.100000E-04)
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ SCF iteration number :   12                                                  +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -328.15405199
+ _______________________________________________________________
+ Fermi energy                               :         0.32658916
+ Kinetic energy                             :       328.82696222
+ Coulomb energy                             :      -630.61070539
+ Exchange energy                            :       -25.59738385
+ Correlation energy                         :        -0.77292497
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00046538
+     valence                                :        14.00000000
+     interstitial                           :         3.68094107
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.93534690
+                  atom     2     C          :         4.38371202
+     total charge in muffin-tins            :        16.31905893
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.04847356
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+ Wall time (seconds)                        :         5.11
+ 
+ RMS change in effective potential (target) :  0.318403E-06  ( 0.100000E-05)
+ Absolute change in total energy   (target) :  0.227604E-05  ( 0.100000E-05)
+ Charge distance                   (target) :  0.582171E-07  ( 0.100000E-04)
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ SCF iteration number :   13                                                  +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -328.15405628
+ _______________________________________________________________
+ Fermi energy                               :         0.32658919
+ Kinetic energy                             :       328.82696392
+ Coulomb energy                             :      -630.61071109
+ Exchange energy                            :       -25.59738412
+ Correlation energy                         :        -0.77292499
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00046538
+     valence                                :        14.00000000
+     interstitial                           :         3.68094119
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.93534734
+                  atom     2     C          :         4.38371148
+     total charge in muffin-tins            :        16.31905881
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.04847349
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+ Wall time (seconds)                        :         5.53
+ 
+ RMS change in effective potential (target) :  0.388732E-07  ( 0.100000E-05)
+ Absolute change in total energy   (target) :  0.428638E-05  ( 0.100000E-05)
+ Charge distance                   (target) :  0.878721E-07  ( 0.100000E-04)
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ SCF iteration number :   14                                                  +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -328.15405538
+ _______________________________________________________________
+ Fermi energy                               :         0.32658919
+ Kinetic energy                             :       328.82696363
+ Coulomb energy                             :      -630.61070998
+ Exchange energy                            :       -25.59738405
+ Correlation energy                         :        -0.77292499
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00046538
+     valence                                :        14.00000000
+     interstitial                           :         3.68094120
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.93534734
+                  atom     2     C          :         4.38371147
+     total charge in muffin-tins            :        16.31905880
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.04847348
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+ Wall time (seconds)                        :         6.02
+ 
+ RMS change in effective potential (target) :  0.634994E-08  ( 0.100000E-05)
+ Absolute change in total energy   (target) :  0.901116E-06  ( 0.100000E-05)
+ Charge distance                   (target) :  0.607296E-08  ( 0.100000E-04)
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ SCF iteration number :   15                                                  +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -328.15405540
+ _______________________________________________________________
+ Fermi energy                               :         0.32658919
+ Kinetic energy                             :       328.82696362
+ Coulomb energy                             :      -630.61070999
+ Exchange energy                            :       -25.59738405
+ Correlation energy                         :        -0.77292499
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00046538
+     valence                                :        14.00000000
+     interstitial                           :         3.68094119
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.93534733
+                  atom     2     C          :         4.38371147
+     total charge in muffin-tins            :        16.31905881
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.04847349
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+ Wall time (seconds)                        :         6.42
+ 
+ RMS change in effective potential (target) :  0.224167E-08  ( 0.100000E-05)
+ Absolute change in total energy   (target) :  0.199092E-07  ( 0.100000E-05)
+ Charge distance                   (target) :  0.851855E-09  ( 0.100000E-04)
+                                                                                
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+| Convergency criteria checked for the last 2 iterations                       +
+| Convergence targets achieved. Performing final SCF iteration                 +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Total energy                               :      -328.15405539
+ _______________________________________________________________
+ Fermi energy                               :         0.32658919
+ Kinetic energy                             :       328.82696362
+ Coulomb energy                             :      -630.61070998
+ Exchange energy                            :       -25.59738405
+ Correlation energy                         :        -0.77292499
+ 
+ DOS at Fermi energy (states/Ha/cell)       :         0.00000000
+ 
+ Electron charges :
+     core                                   :         6.00000000
+     core leakage                           :         0.00046538
+     valence                                :        14.00000000
+     interstitial                           :         3.68094119
+     charge in muffin-tin spheres :
+                  atom     1    Si          :        11.93534733
+                  atom     2     C          :         4.38371147
+     total charge in muffin-tins            :        16.31905881
+     total charge                           :        20.00000000
+ 
+ Estimated fundamental gap                  :         0.04847349
+        valence-band maximum at    1      0.0000  0.0000  0.0000
+     conduction-band minimum at    8      0.5000  0.5000  0.0000
+ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ Self-consistent loop stopped                                                 +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ STATE.OUT is written
+ 
+********************************************************************************
+* Groundstate module stopped                                                   *
+********************************************************************************
+ 
+ Total time spent (seconds)                 :         5.84
+================================================================================
+| EXCITING OXYGEN stopped                                                      =
+================================================================================

--- a/tests/data/exciting/species_example/LINENGY.OUT
+++ b/tests/data/exciting/species_example/LINENGY.OUT
@@ -1,0 +1,60 @@
+ 
+Species :    1 (Si), atom :    1
+ APW functions :
+ # only order=1 because we said to use 
+ # APW+LO for l=0 and l=1
+ # energies have been found by the search
+  l =  0, order =  1 :   0.1500000000    
+  l =  1, order =  1 :   0.4150000000    
+ # order=1 and order=2 for l>1 because we
+ # specified LAPW as default basis
+ # energies were fixed and have not been varied by the search
+  l =  2, order =  1 :   0.1500000000    
+  l =  2, order =  2 :   0.1500000000    
+  l =  3, order =  1 :   0.1500000000    
+  l =  3, order =  2 :   0.1500000000    
+  l =  4, order =  1 :   0.1500000000    
+  l =  4, order =  2 :   0.1500000000    
+  l =  5, order =  1 :   0.1500000000    
+  l =  5, order =  2 :   0.1500000000    
+  l =  6, order =  1 :   0.1500000000    
+  l =  6, order =  2 :   0.1500000000    
+  l =  7, order =  1 :   0.1500000000    
+  l =  7, order =  2 :   0.1500000000    
+  l =  8, order =  1 :   0.1500000000    
+  l =  8, order =  2 :   0.1500000000    
+ local-orbital functions :
+ # LOs from APW+LO for l=0 and l=1
+ # energies found by search
+  l.o. =  1, l =  0, order =  1 :   0.1500000000    
+  l.o. =  1, l =  0, order =  2 :   0.1500000000    
+  l.o. =  2, l =  1, order =  1 :   0.4150000000    
+  l.o. =  2, l =  1, order =  2 :   0.4150000000    
+ # custom LOs for semi-core states
+ # energies found by search
+  l.o. =  3, l =  1, order =  1 :   0.4150000000    
+  l.o. =  3, l =  1, order =  2 :   -2.976250000    
+ 
+Species :    2 (C), atom :    1
+ APW functions :
+  l =  0, order =  1 :   0.1500000000    
+  l =  1, order =  1 :   0.2725000000    
+  l =  2, order =  1 :   0.1500000000    
+  l =  2, order =  2 :   0.1500000000    
+  l =  3, order =  1 :   0.1500000000    
+  l =  3, order =  2 :   0.1500000000    
+  l =  4, order =  1 :   0.1500000000    
+  l =  4, order =  2 :   0.1500000000    
+  l =  5, order =  1 :   0.1500000000    
+  l =  5, order =  2 :   0.1500000000    
+  l =  6, order =  1 :   0.1500000000    
+  l =  6, order =  2 :   0.1500000000    
+  l =  7, order =  1 :   0.1500000000    
+  l =  7, order =  2 :   0.1500000000    
+  l =  8, order =  1 :   0.1500000000    
+  l =  8, order =  2 :   0.1500000000    
+ local-orbital functions :
+  l.o. =  1, l =  0, order =  1 :   0.1500000000    
+  l.o. =  1, l =  0, order =  2 :   0.1500000000    
+  l.o. =  2, l =  1, order =  1 :   0.2725000000    
+  l.o. =  2, l =  1, order =  2 :   0.2725000000    

--- a/tests/data/exciting/species_example/Si.xml
+++ b/tests/data/exciting/species_example/Si.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spdb xsi:noNamespaceSchemaLocation="../../xml/species.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <sp chemicalSymbol="Si" name="silicon" z="-14.0000" mass="51196.73454">
+    <muffinTin rmin="0.100000E-04" radius="2.0000" rinf="24.9760" radialmeshPoints="300"/>
+    <atomicState n="1" l="0" kappa="1" occ="2.00000" core="true"/>
+    <atomicState n="2" l="0" kappa="1" occ="2.00000" core="true"/>
+    <!-- these two states are core states in the default species files
+    and have been customly set to be treated as valence states -->
+    <atomicState n="2" l="1" kappa="1" occ="2.00000" core="false"/>
+    <atomicState n="2" l="1" kappa="2" occ="4.00000" core="false"/>
+    <!-- -->
+    <atomicState n="3" l="0" kappa="1" occ="2.00000" core="false"/>
+    <atomicState n="3" l="1" kappa="1" occ="1.00000" core="false"/>
+    <atomicState n="3" l="1" kappa="2" occ="1.00000" core="false"/>
+    <basis>
+      <!-- use LAPW as default -->
+      <default type="lapw" trialEnergy="0.1500" searchE="false"/>
+      <!-- unless for l=0 and l=1, where we use APW+LO-->
+      <custom l="0" type="apw+lo" trialEnergy="0.1500" searchE="true"/>
+      <custom l="1" type="apw+lo" trialEnergy="0.1500" searchE="true"/>
+      <!-- these are custom LOs to account for the two states that have
+        been removed from the core. We set the second trialEnergy for
+        the semi-core state based on atoms.xml -->
+      <lo l="1">
+        <wf matchingOrder="0" trialEnergy="0.1500" searchE="true"/>
+        <wf matchingOrder="0" trialEnergy="-3.51" searchE="true"/>
+      </lo>
+    </basis>
+  </sp>
+</spdb>

--- a/tests/data/exciting/species_example/Si_scf.xml
+++ b/tests/data/exciting/species_example/Si_scf.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spdb xsi:noNamespaceSchemaLocation="../../xml/species.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <sp chemicalSymbol="Si" name="silicon" z="-14.0000" mass="51196.73454">
+    <muffinTin rmin="0.100000E-04" radius="2.0000" rinf="24.9760" radialmeshPoints="300"/>
+    <atomicState n="1" l="0" kappa="1" occ="2.00000" core="true"/>
+    <atomicState n="2" l="0" kappa="1" occ="2.00000" core="true"/>
+    <atomicState n="2" l="1" kappa="1" occ="2.00000" core="false"/>
+    <atomicState n="2" l="1" kappa="2" occ="4.00000" core="false"/>
+    <atomicState n="3" l="0" kappa="1" occ="2.00000" core="false"/>
+    <atomicState n="3" l="1" kappa="1" occ="1.00000" core="false"/>
+    <atomicState n="3" l="1" kappa="2" occ="1.00000" core="false"/>
+    <basis>
+      <default>
+        <!-- energy parameter for LAPW was set to be fixed at 0.15 -->
+        <wf matchingOrder="0" trialEnergy="0.1500" searchE="false"/>
+      </default>
+      <custom l="0">
+        <!-- energy parameter for l=0 APW+LO was initialized with 0.15
+          and free to vary, but the search didn't change it -->
+        <wf matchingOrder="0" trialEnergy="0.1500" searchE="true"/>
+      </custom>
+      <custom l="1">
+        <!-- energy parameter for l=1 APW+LO was initialized with 0.15
+          and free to vary and the search found 0.415 to be a good value -->
+        <wf matchingOrder="0" trialEnergy="0.4150" searchE="true"/>
+      </custom>
+
+      <!-- these are the LOs corresponding to the l=0 and l=1 APW+LO -->
+      <lo l="0">
+        <wf matchingOrder="0" trialEnergy="0.1500" searchE="true"/>
+        <wf matchingOrder="1" trialEnergy="0.1500" searchE="true"/>
+      </lo>
+      <lo l="1">
+        <wf matchingOrder="0" trialEnergy="0.4150" searchE="true"/>
+        <wf matchingOrder="1" trialEnergy="0.4150" searchE="true"/>
+      </lo>
+
+      <!-- these are our custom LOs for the semi-core states.
+        We initialized the trialEnergy with 0.15 and -3.51, respectively
+        and they were set to 0.415 and -2.9763 after the search. -->
+      <lo l="1">
+        <wf matchingOrder="0" trialEnergy="0.4150" searchE="true"/>
+        <wf matchingOrder="0" trialEnergy="-2.9763" searchE="true"/>
+      </lo>
+    </basis>
+    <!-- This file was automatically generated-->
+    <!-- Default linearization energies have been replaced by that -->
+    <!-- found using findlinentype='Wigner_Seitz' method -->
+  </sp>
+</spdb>

--- a/tests/data/exciting/species_example/atoms.xml
+++ b/tests/data/exciting/species_example/atoms.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<atomlist>
+  <Hamiltonian RelativityModel="dirac" xctype="3"/>
+  <atom chemicalSymbol="Si" species="Si.xml">
+    <NumericalSetup TotalNumberOfGridPoints="696" NumberOfMTGridPoints="300" GridType="cubic" rmin="1.000000000000e-5" rmt="2.000000000000e0" rmax="2.511706247834e1"/>
+    <spectrum>
+      <state n="1" l="0" kappa="1" energy="-65.3520528725"/>
+      <state n="2" l="0" kappa="1" energy="-5.09800653744"/>
+      <!-- we descide that these two states are not very deep in energy
+        and we want to treat them as valence (semi-core) states -->
+      <state n="2" l="1" kappa="1" energy="-3.52865042570"/>
+      <state n="2" l="1" kappa="2" energy="-3.50489097060"/>
+      <!-- -->
+      <state n="3" l="0" kappa="1" energy="-0.399635387060"/>
+      <state n="3" l="1" kappa="1" energy="-0.153659685366"/>
+      <state n="3" l="1" kappa="2" energy="-0.152458706009"/>
+    </spectrum>
+  </atom>
+  <atom chemicalSymbol="C" species="C.xml">
+    <NumericalSetup TotalNumberOfGridPoints="610" NumberOfMTGridPoints="250" GridType="cubic" rmin="1.000000000000e-5" rmt="1.450000000000e0" rmax="2.121382825003e1"/>
+    <spectrum>
+      <state n="1" l="0" kappa="1" energy="-9.95167919505"/>
+      <state n="2" l="0" kappa="1" energy="-0.501191285063"/>
+      <state n="2" l="1" kappa="1" energy="-0.199206966270"/>
+      <state n="2" l="1" kappa="2" energy="-0.198880646168"/>
+    </spectrum>
+  </atom>
+</atomlist>

--- a/tests/data/exciting/species_example/input.xml
+++ b/tests/data/exciting/species_example/input.xml
@@ -1,0 +1,31 @@
+<input>
+
+  <title>SiC DFPT phonons</title>
+
+  <structure speciespath="./">
+    <crystal scale="8.244205906996132">
+      <basevect>0.0   0.5   0.5</basevect>
+      <basevect>0.5   0.0   0.5</basevect>
+      <basevect>0.5   0.5   0.0</basevect>
+    </crystal>
+    <species chemicalSymbol="Si" speciesfile="Si.xml">
+      <atom coord="0.00000000000000 0.00000000000000 0.00000000000000"/>
+    </species>
+    <species chemicalSymbol="C" speciesfile="C.xml">
+      <atom coord="0.25000000000000 0.25000000000000 0.25000000000000"/>
+    </species>
+  </structure>
+
+  <groundstate 
+    do="fromscratch"
+    ngridk="4 4 4"
+    reducek="true"
+    rgkmax="6"
+    gmaxvr="10"
+    nempty="50"
+    >
+    <libxc correlation='XC_GGA_C_PBE' exchange='XC_GGA_X_PBE'/>
+  </groundstate>
+
+
+</input>

--- a/tests/test_abacusparser.py
+++ b/tests/test_abacusparser.py
@@ -53,7 +53,7 @@ def test_band(parser):
 
     sec_method = sec_run.method[0]
     sec_basis_set = sec_method.electronic_model[0].basis_set[0]
-    assert sec_basis_set.type == 'numerical AOs'
+    assert sec_basis_set.type == 'numeric AOs'
     assert sec_basis_set.cutoff.to('Ry').magnitude == approx(50)
     sec_basis_set = sec_method.electronic_model[1].basis_set[0]
     assert sec_basis_set.x_abacus_basis_sets_delta_k.magnitude == approx(0.01)
@@ -200,7 +200,7 @@ def test_geomopt(parser):
     assert sec_method.electronic.smearing.kind == 'gaussian'
     assert sec_method.electronic.smearing.width == approx(2.179872361103585e-20)
     assert sec_method.x_abacus_gamma_algorithms
-    assert sec_method.electronic_model[0].basis_set[0].type == 'numerical atomic orbitals'
+    assert sec_method.electronic_model[0].basis_set[0].type == 'numeric AOs'
 
     sec_workflow = archive.workflow[0]
     assert sec_workflow.type == 'geometry_optimization'

--- a/tests/test_abacusparser.py
+++ b/tests/test_abacusparser.py
@@ -52,10 +52,10 @@ def test_band(parser):
     assert sec_run.clean_end
 
     sec_method = sec_run.method[0]
-    sec_basis_set = sec_method.electronic_model[0].basis_set[0]
+    sec_basis_set = sec_method.electrons_representation[0].basis_set[0]
     assert sec_basis_set.type == 'numeric AOs'
     assert sec_basis_set.cutoff.to('Ry').magnitude == approx(50)
-    sec_basis_set = sec_method.electronic_model[1].basis_set[0]
+    sec_basis_set = sec_method.electrons_representation[1].basis_set[0]
     assert sec_basis_set.x_abacus_basis_sets_delta_k.magnitude == approx(0.01)
     assert sec_basis_set.x_abacus_basis_sets_delta_r.magnitude == approx(0.01)
     assert sec_basis_set.x_abacus_basis_sets_dr_uniform.magnitude == approx(0.001)
@@ -200,7 +200,7 @@ def test_geomopt(parser):
     assert sec_method.electronic.smearing.kind == 'gaussian'
     assert sec_method.electronic.smearing.width == approx(2.179872361103585e-20)
     assert sec_method.x_abacus_gamma_algorithms
-    assert sec_method.electronic_model[0].basis_set[0].type == 'numeric AOs'
+    assert sec_method.electrons_representation[0].basis_set[0].type == 'numeric AOs'
 
     sec_workflow = archive.workflow[0]
     assert sec_workflow.type == 'geometry_optimization'

--- a/tests/test_abacusparser.py
+++ b/tests/test_abacusparser.py
@@ -52,19 +52,16 @@ def test_band(parser):
     assert sec_run.clean_end
 
     sec_method = sec_run.method[0]
-    assert sec_method.basis_set[0].type == 'Numeric AOs'
-    assert sec_method.x_abacus_basis_type == 'lcao'
-    assert sec_method.x_abacus_number_of_pw_for_wavefunction == 2085
-    assert sec_method.x_abacus_number_of_sticks_for_density == 721
-    assert sec_method.basis_set[0].cell_dependent[0].name == 'PW_50.0'
-    assert sec_method.basis_set[1].cell_dependent[0].planewave_cutoff.magnitude == approx(4.35974472220717e-16)
-    sec_basis_sets = sec_method.x_abacus_section_basis_sets[0]
-    assert sec_basis_sets.x_abacus_basis_sets_delta_k.magnitude == approx(0.01)
-    assert sec_basis_sets.x_abacus_basis_sets_delta_r.magnitude == approx(0.01)
-    assert sec_basis_sets.x_abacus_basis_sets_dr_uniform.magnitude == approx(0.001)
-    assert sec_basis_sets.x_abacus_basis_sets_rmax.magnitude == approx(30)
-    assert sec_basis_sets.x_abacus_basis_sets_kmesh == 711
-    sec_specie_basis_set = sec_basis_sets.x_abacus_section_specie_basis_set
+    sec_basis_set = sec_method.electronic_model[0].basis_set[0]
+    assert sec_basis_set.type == 'numerical atomic orbitals'
+    assert sec_basis_set.cutoff.to('Ry').magnitude == approx(50)
+    sec_basis_set = sec_method.electronic_model[1].basis_set[0]
+    assert sec_basis_set.x_abacus_basis_sets_delta_k.magnitude == approx(0.01)
+    assert sec_basis_set.x_abacus_basis_sets_delta_r.magnitude == approx(0.01)
+    assert sec_basis_set.x_abacus_basis_sets_dr_uniform.magnitude == approx(0.001)
+    assert sec_basis_set.x_abacus_basis_sets_rmax.magnitude == approx(30)
+    assert sec_basis_set.x_abacus_basis_sets_kmesh == 711  # Update test to new KMesh
+    sec_specie_basis_set = sec_basis_set.x_abacus_section_specie_basis_set
     assert sec_specie_basis_set[0].x_abacus_specie_basis_set_filename == 'Si_lda_8.0au_50Ry_2s2p1d'
     assert (sec_specie_basis_set[0].x_abacus_specie_basis_set_ln == [
             [0, 0], [0, 1], [1, 0], [1, 1], [2, 0]]).all()
@@ -203,7 +200,7 @@ def test_geomopt(parser):
     assert sec_method.electronic.smearing.kind == 'gaussian'
     assert sec_method.electronic.smearing.width == approx(2.179872361103585e-20)
     assert sec_method.x_abacus_gamma_algorithms
-    assert sec_method.x_abacus_basis_type == 'lcao'
+    assert sec_method.electronic_model[0].basis_set[0].type == 'numerical atomic orbitals'
 
     sec_workflow = archive.workflow[0]
     assert sec_workflow.type == 'geometry_optimization'

--- a/tests/test_abacusparser.py
+++ b/tests/test_abacusparser.py
@@ -53,7 +53,7 @@ def test_band(parser):
 
     sec_method = sec_run.method[0]
     sec_basis_set = sec_method.electronic_model[0].basis_set[0]
-    assert sec_basis_set.type == 'numerical atomic orbitals'
+    assert sec_basis_set.type == 'numerical AOs'
     assert sec_basis_set.cutoff.to('Ry').magnitude == approx(50)
     sec_basis_set = sec_method.electronic_model[1].basis_set[0]
     assert sec_basis_set.x_abacus_basis_sets_delta_k.magnitude == approx(0.01)

--- a/tests/test_abinitparser.py
+++ b/tests/test_abinitparser.py
@@ -49,8 +49,7 @@ def test_scf(parser):
     sec_method = sec_run.method[0]
     assert sec_method.scf.n_max_iteration == 10.
     assert sec_method.scf.threshold_energy_change.magnitude == approx(4.35974472e-24)
-    assert sec_method.basis_set[0].cell_dependent[0].planewave_cutoff.magnitude == approx(3.48779578e-17)
-    assert sec_method.basis_set[0].kind == 'wavefunction'
+    assert sec_method.electronic_model[0].basis_set[0].cutoff.to('hartree').magnitude == approx(8)
     assert sec_method.dft.xc_functional.contributions[0].name == 'LDA_XC_TETER93'
 
     sec_system = sec_run.system[0]

--- a/tests/test_abinitparser.py
+++ b/tests/test_abinitparser.py
@@ -49,7 +49,7 @@ def test_scf(parser):
     sec_method = sec_run.method[0]
     assert sec_method.scf.n_max_iteration == 10.
     assert sec_method.scf.threshold_energy_change.magnitude == approx(4.35974472e-24)
-    assert sec_method.electronic_model[0].basis_set[0].cutoff.to('hartree').magnitude == approx(8)
+    assert sec_method.electrons_representation[0].basis_set[0].cutoff.to('hartree').magnitude == approx(8)
     assert sec_method.dft.xc_functional.contributions[0].name == 'LDA_XC_TETER93'
 
     sec_system = sec_run.system[0]

--- a/tests/test_castepparser.py
+++ b/tests/test_castepparser.py
@@ -42,7 +42,7 @@ def test_single_point(parser):
     assert sec_run.time_run.date_start.magnitude == 1455286325.0
 
     sec_method = sec_run.method[0]
-    assert sec_method.basis_set[0].cell_dependent[0].name == 'PW_7'
+    assert sec_method.electronic_model[0].basis_set[0].cutoff.to('eV').magnitude == approx(100)
     assert sec_method.electronic.n_spin_channels == 1
     assert sec_method.dft.xc_functional.correlation[0].name == 'GGA_C_PBE'
     assert sec_method.electronic.smearing.kind == 'gaussian'

--- a/tests/test_castepparser.py
+++ b/tests/test_castepparser.py
@@ -42,7 +42,7 @@ def test_single_point(parser):
     assert sec_run.time_run.date_start.magnitude == 1455286325.0
 
     sec_method = sec_run.method[0]
-    assert sec_method.electronic_model[0].basis_set[0].cutoff.to('eV').magnitude == approx(100)
+    assert sec_method.electrons_representation[0].basis_set[0].cutoff.to('eV').magnitude == approx(100)
     assert sec_method.electronic.n_spin_channels == 1
     assert sec_method.dft.xc_functional.correlation[0].name == 'GGA_C_PBE'
     assert sec_method.electronic.smearing.kind == 'gaussian'

--- a/tests/test_cp2kparser.py
+++ b/tests/test_cp2kparser.py
@@ -51,8 +51,9 @@ def test_single_point(parser):
     assert sec_force_eval_dft.x_cp2k_section_input_FORCE_EVAL_DFT_SCF[0].x_cp2k_input_FORCE_EVAL_DFT_SCF_EPS_SCF == '1.0E-7'
 
     sec_method = sec_run.method[0]
-    assert sec_method.basis_set[0].atom_centered[0].name == 'DZVP-GTH-PADE'
-    assert sec_method.basis_set[0].cell_dependent[0].planewave_cutoff.magnitude == approx(6.53961708e-16)
+    sec_basis_sets = sec_method.electronic_model[0].basis_set
+    assert sec_basis_sets[0].cutoff.magnitude == approx(6.53961708e-16)
+    assert sec_basis_sets[1].atom_centered[0].name == 'DZVP-GTH-PADE'
     assert sec_method.scf.threshold_energy_change.magnitude == approx(4.35974472220717e-25)
     assert sec_method.dft.xc_functional.contributions[0].name == 'LDA_XC_TETER93'
     sec_qs_settings = sec_method.x_cp2k_section_quickstep_settings[0]

--- a/tests/test_cp2kparser.py
+++ b/tests/test_cp2kparser.py
@@ -51,7 +51,7 @@ def test_single_point(parser):
     assert sec_force_eval_dft.x_cp2k_section_input_FORCE_EVAL_DFT_SCF[0].x_cp2k_input_FORCE_EVAL_DFT_SCF_EPS_SCF == '1.0E-7'
 
     sec_method = sec_run.method[0]
-    sec_basis_sets = sec_method.electronic_model[0].basis_set
+    sec_basis_sets = sec_method.electrons_representation[0].basis_set
     assert sec_basis_sets[0].cutoff.magnitude == approx(6.53961708e-16)
     assert sec_basis_sets[1].atom_centered[0].name == 'DZVP-GTH-PADE'
     assert sec_method.scf.threshold_energy_change.magnitude == approx(4.35974472220717e-25)

--- a/tests/test_cpmdparser.py
+++ b/tests/test_cpmdparser.py
@@ -53,7 +53,7 @@ def test_single_point(parser):
     assert sec_calc[0].energy.xc.value.magnitude == approx(-2.50324989e-18)
 
     sec_method = run.method
-    assert sec_method[0].basis_set[0].cell_dependent[0].name == 'PW_70.0'
+    assert sec_method[0].electronic_model[0].basis_set[0].cutoff.to('Ry').magnitude == approx(70.0)
     assert sec_method[0].x_cpmd_simulation_parameters['TIME STEP FOR ELECTRONS'] == 5.0
     assert sec_method[0].x_cpmd_simulation_parameters['MAXIMUM NUMBER OF ITERATIONS FOR SC'] == 10000
 

--- a/tests/test_cpmdparser.py
+++ b/tests/test_cpmdparser.py
@@ -53,7 +53,7 @@ def test_single_point(parser):
     assert sec_calc[0].energy.xc.value.magnitude == approx(-2.50324989e-18)
 
     sec_method = run.method
-    assert sec_method[0].electronic_model[0].basis_set[0].cutoff.to('Ry').magnitude == approx(70.0)
+    assert sec_method[0].electrons_representation[0].basis_set[0].cutoff.to('Ry').magnitude == approx(70.0)
     assert sec_method[0].x_cpmd_simulation_parameters['TIME STEP FOR ELECTRONS'] == 5.0
     assert sec_method[0].x_cpmd_simulation_parameters['MAXIMUM NUMBER OF ITERATIONS FOR SC'] == 10000
 

--- a/tests/test_crystalparser.py
+++ b/tests/test_crystalparser.py
@@ -286,7 +286,7 @@ def asserts_basic_code_specific(archive, method_type="DFT", system_type="3D", ru
     method = run.method[0]
 
     assert run.program.name == "Crystal"
-    assert method.basis_set[0].type == "gaussians"
+    assert method.electronic_model[0].basis_set[0].type == "gaussians"
 
     assert method.x_crystal_n_atoms is not None
     assert method.x_crystal_n_shells is not None
@@ -313,7 +313,7 @@ def asserts_basic_code_specific(archive, method_type="DFT", system_type="3D", ru
         assert method.x_crystal_shrink is not None
     assert method.x_crystal_weight_f is not None
 
-    bases = method.basis_set[0].atom_centered
+    bases = method.electronic_model[0].basis_set[0].atom_centered
     for basis in bases:
         assert isinstance(basis.atom_number, np.int32)
         for shell in basis.x_crystal_section_shell:

--- a/tests/test_crystalparser.py
+++ b/tests/test_crystalparser.py
@@ -286,7 +286,7 @@ def asserts_basic_code_specific(archive, method_type="DFT", system_type="3D", ru
     method = run.method[0]
 
     assert run.program.name == "Crystal"
-    assert method.electronic_model[0].basis_set[0].type == "gaussians"
+    assert method.electrons_representation[0].basis_set[0].type == "gaussians"
 
     assert method.x_crystal_n_atoms is not None
     assert method.x_crystal_n_shells is not None
@@ -313,7 +313,7 @@ def asserts_basic_code_specific(archive, method_type="DFT", system_type="3D", ru
         assert method.x_crystal_shrink is not None
     assert method.x_crystal_weight_f is not None
 
-    bases = method.electronic_model[0].basis_set[0].atom_centered
+    bases = method.electrons_representation[0].basis_set[0].atom_centered
     for basis in bases:
         assert isinstance(basis.atom_number, np.int32)
         for shell in basis.x_crystal_section_shell:

--- a/tests/test_gamessparser.py
+++ b/tests/test_gamessparser.py
@@ -38,8 +38,9 @@ def test_dft(parser):
 
     sec_method = archive.run[0].method
     assert sec_method[0].dft.xc_functional.correlation[0].name == 'LDA_C_VWN_5'
-    assert sec_method[0].basis_set[0].name == '6-31G(d)'
-    assert sec_method[0].basis_set[0].atom_centered[0].name == 'N31'
+    sec_basis_ac = sec_method[0].electronic_model[0].basis_set[0].atom_centered[0]
+    assert sec_basis_ac.formula == '6-31G(d)'
+    assert sec_basis_ac.name == 'N31'
 
     sec_system = archive.run[0].system
     assert sec_system[2].atoms.labels == ['C', 'C', 'H', 'H']

--- a/tests/test_gamessparser.py
+++ b/tests/test_gamessparser.py
@@ -38,7 +38,7 @@ def test_dft(parser):
 
     sec_method = archive.run[0].method
     assert sec_method[0].dft.xc_functional.correlation[0].name == 'LDA_C_VWN_5'
-    sec_basis_ac = sec_method[0].electronic_model[0].basis_set[0].atom_centered[0]
+    sec_basis_ac = sec_method[0].electrons_representation[0].basis_set[0].atom_centered[0]
     assert sec_basis_ac.formula == '6-31G(d)'
     assert sec_basis_ac.name == 'N31'
 

--- a/tests/test_gaussianparser.py
+++ b/tests/test_gaussianparser.py
@@ -43,7 +43,7 @@ def test_scf_spinpol(parser):
     assert len(sec_runs[0].x_gaussian_section_orbital_symmetries[0].x_gaussian_alpha_symmetries) == 50
 
     sec_methods = sec_runs[0].method
-    assert sec_methods[0].basis_set[0].atom_centered[0].name == 'AUG-CC-PVTZ'
+    assert sec_methods[0].electronic_model[0].basis_set[0].atom_centered[0].name == 'AUG-CC-PVTZ'
     assert len(sec_methods) == 1
     assert sec_methods[0].dft.xc_functional.hybrid[0].name == 'HYB_GGA_XC_B3LYP'
     assert sec_methods[0].electronic.charge.magnitude == -1

--- a/tests/test_gaussianparser.py
+++ b/tests/test_gaussianparser.py
@@ -43,7 +43,7 @@ def test_scf_spinpol(parser):
     assert len(sec_runs[0].x_gaussian_section_orbital_symmetries[0].x_gaussian_alpha_symmetries) == 50
 
     sec_methods = sec_runs[0].method
-    assert sec_methods[0].electronic_model[0].basis_set[0].atom_centered[0].name == 'AUG-CC-PVTZ'
+    assert sec_methods[0].electrons_representation[0].basis_set[0].atom_centered[0].name == 'AUG-CC-PVTZ'
     assert len(sec_methods) == 1
     assert sec_methods[0].dft.xc_functional.hybrid[0].name == 'HYB_GGA_XC_B3LYP'
     assert sec_methods[0].electronic.charge.magnitude == -1

--- a/tests/test_gpawparser.py
+++ b/tests/test_gpawparser.py
@@ -39,8 +39,8 @@ def test_gpw(parser):
     assert archive.run[0].program.version == '1.1.0'
 
     sec_method = archive.run[0].method[0]
-    assert sec_method.basis_set[0].cell_dependent[0].kind == 'real space grid'
-    assert sec_method.basis_set[0].cell_dependent[0].name == 'GR_20900.5'
+    sec_basis = sec_method.electronic_model[0].basis_set[0]
+    assert sec_basis.type == 'real-space grid'
     assert sec_method.scf.threshold_energy_change.magnitude == approx(1.42196374e-24)
     assert sec_method.electronic.smearing.width == 0.0
     assert sec_method.electronic.charge == 0.0
@@ -72,8 +72,9 @@ def test_gpw2(parser):
     assert archive.run[0].program.version == '1.1.1b1'
 
     sec_method = archive.run[0].method[0]
-    assert sec_method.basis_set[0].cell_dependent[0].kind == 'plane waves'
-    assert sec_method.basis_set[0].cell_dependent[0].planewave_cutoff.magnitude == approx(4.8065299e-17)
+    sec_basis = sec_method.electronic_model[0].basis_set[0]
+    assert sec_basis.type == 'plane waves'
+    assert sec_basis.cutoff.magnitude == approx(4.8065299e-17)
     assert sec_method.scf.threshold_energy_change.magnitude == approx(8.01088317e-23)
     assert sec_method.electronic.smearing.width == approx(1.60217663e-20)
     assert not sec_method.x_gpaw_fix_density
@@ -112,8 +113,9 @@ def test_lcao(parser):
 
     assert archive.run[0].program.version == '1.1.1b1'
 
-    assert archive.run[0].method[0].basis_set[0].atom_centered[0].kind == 'numeric AOs'
-    assert archive.run[0].method[0].basis_set[0].atom_centered[0].name == 'dzp'
+    sec_method = archive.run[0].method[0]
+    sec_basis = sec_method.electronic_model[0].basis_set[0]
+    assert sec_basis.type == 'numerical AOs'
 
     sec_density = archive.run[0].calculation[0].density_charge[0]
     sec_potential = archive.run[0].calculation[0].potential[0].effective[0]

--- a/tests/test_gpawparser.py
+++ b/tests/test_gpawparser.py
@@ -39,7 +39,7 @@ def test_gpw(parser):
     assert archive.run[0].program.version == '1.1.0'
 
     sec_method = archive.run[0].method[0]
-    sec_basis = sec_method.electronic_model[0].basis_set[0]
+    sec_basis = sec_method.electrons_representation[0].basis_set[0]
     assert sec_basis.type == 'real-space grid'
     assert sec_method.scf.threshold_energy_change.magnitude == approx(1.42196374e-24)
     assert sec_method.electronic.smearing.width == 0.0
@@ -72,7 +72,7 @@ def test_gpw2(parser):
     assert archive.run[0].program.version == '1.1.1b1'
 
     sec_method = archive.run[0].method[0]
-    sec_basis = sec_method.electronic_model[0].basis_set[0]
+    sec_basis = sec_method.electrons_representation[0].basis_set[0]
     assert sec_basis.type == 'plane waves'
     assert sec_basis.cutoff.magnitude == approx(4.8065299e-17)
     assert sec_method.scf.threshold_energy_change.magnitude == approx(8.01088317e-23)
@@ -114,7 +114,7 @@ def test_lcao(parser):
     assert archive.run[0].program.version == '1.1.1b1'
 
     sec_method = archive.run[0].method[0]
-    sec_basis = sec_method.electronic_model[0].basis_set[0]
+    sec_basis = sec_method.electrons_representation[0].basis_set[0]
     assert sec_basis.type == 'numeric AOs'
 
     sec_density = archive.run[0].calculation[0].density_charge[0]

--- a/tests/test_gpawparser.py
+++ b/tests/test_gpawparser.py
@@ -115,7 +115,7 @@ def test_lcao(parser):
 
     sec_method = archive.run[0].method[0]
     sec_basis = sec_method.electronic_model[0].basis_set[0]
-    assert sec_basis.type == 'numerical AOs'
+    assert sec_basis.type == 'numeric AOs'
 
     sec_density = archive.run[0].calculation[0].density_charge[0]
     sec_potential = archive.run[0].calculation[0].potential[0].effective[0]

--- a/tests/test_nwchemparser.py
+++ b/tests/test_nwchemparser.py
@@ -40,7 +40,7 @@ def test_single_point(parser):
     assert sec_run.x_nwchem_section_start_information[0].x_nwchem_ga_revision == '10594'
 
     sec_method = archive.run[0].method[0]
-    assert sec_method.electronic_model[0].basis_set[0].type == 'gaussians'
+    assert sec_method.electrons_representation[0].basis_set[0].type == 'gaussians'
     assert sec_method.scf.n_max_iteration == 50
     assert len(sec_method.dft.xc_functional.correlation) == 1
     assert sec_method.dft.xc_functional.correlation[0].name == 'MGGA_C_TPSS'

--- a/tests/test_nwchemparser.py
+++ b/tests/test_nwchemparser.py
@@ -40,7 +40,7 @@ def test_single_point(parser):
     assert sec_run.x_nwchem_section_start_information[0].x_nwchem_ga_revision == '10594'
 
     sec_method = archive.run[0].method[0]
-    assert sec_method.basis_set[0].type == 'gaussians'
+    assert sec_method.electronic_model[0].basis_set[0].type == 'gaussians'
     assert sec_method.scf.n_max_iteration == 50
     assert len(sec_method.dft.xc_functional.correlation) == 1
     assert sec_method.dft.xc_functional.correlation[0].name == 'MGGA_C_TPSS'

--- a/tests/test_onetepparser.py
+++ b/tests/test_onetepparser.py
@@ -54,6 +54,9 @@ def test_scf(parser):
     assert sec_scc[0].energy.xc.value.magnitude == approx(-6.21292141e-17)
     assert len(sec_scc[0].scf_iteration) == 4
 
+    sec_method = sec_run.method[0]
+    assert sec_method.electronic_model[0].basis_set[0].cutoff.to('Ha').magnitude == approx(30.38533)
+
 
 def test_relax(parser):
     archive = EntryArchive()
@@ -63,6 +66,7 @@ def test_relax(parser):
     sec_method = archive.run[0].method
     assert sec_method[0].dft.xc_functional.exchange[0].name == 'LDA_X_PZ'
     assert sec_method[0].x_onetep_input_parameters['ngwf_threshold_orig'] == approx(1e-5)
+    assert sec_method[0].electronic_model[0].basis_set[0].cutoff.to('Ha').magnitude == approx(20.05907)
 
     sec_system = archive.run[0].system
     assert len(sec_system) == 3
@@ -85,6 +89,9 @@ def test_tddft(parser):
 
     parser.parse('tests/data/onetep/ethene/ethene_tddft.out', archive, None)
 
+    sec_method = archive.run[0].method
+    assert sec_method[0].electronic_model[0].basis_set[0].cutoff.to('Ha').magnitude == approx(14.88881)
+
     sec_scc = archive.run[0].calculation
     assert len(sec_scc) == 1
     assert sec_scc[0].energy.total.value.magnitude == approx(2.60907575e-18)
@@ -99,6 +106,9 @@ def test_charges(parser):
     archive = EntryArchive()
 
     parser.parse('tests/data/onetep/test20/test20.out', archive, None)
+
+    sec_method = archive.run[0].method
+    assert sec_method[0].electronic_model[0].basis_set[0].cutoff.to('Ha').magnitude == approx(31.36667)
 
     sec_scc = archive.run[0].calculation
     assert len(sec_scc) == 1

--- a/tests/test_onetepparser.py
+++ b/tests/test_onetepparser.py
@@ -55,7 +55,7 @@ def test_scf(parser):
     assert len(sec_scc[0].scf_iteration) == 4
 
     sec_method = sec_run.method[0]
-    assert sec_method.electronic_model[0].basis_set[0].cutoff.to('Ha').magnitude == approx(30.38533)
+    assert sec_method.electrons_representation[0].basis_set[0].cutoff.to('Ha').magnitude == approx(30.38533)
 
 
 def test_relax(parser):
@@ -66,7 +66,7 @@ def test_relax(parser):
     sec_method = archive.run[0].method
     assert sec_method[0].dft.xc_functional.exchange[0].name == 'LDA_X_PZ'
     assert sec_method[0].x_onetep_input_parameters['ngwf_threshold_orig'] == approx(1e-5)
-    assert sec_method[0].electronic_model[0].basis_set[0].cutoff.to('Ha').magnitude == approx(20.05907)
+    assert sec_method[0].electrons_representation[0].basis_set[0].cutoff.to('Ha').magnitude == approx(20.05907)
 
     sec_system = archive.run[0].system
     assert len(sec_system) == 3
@@ -90,7 +90,7 @@ def test_tddft(parser):
     parser.parse('tests/data/onetep/ethene/ethene_tddft.out', archive, None)
 
     sec_method = archive.run[0].method
-    assert sec_method[0].electronic_model[0].basis_set[0].cutoff.to('Ha').magnitude == approx(14.88881)
+    assert sec_method[0].electrons_representation[0].basis_set[0].cutoff.to('Ha').magnitude == approx(14.88881)
 
     sec_scc = archive.run[0].calculation
     assert len(sec_scc) == 1
@@ -108,7 +108,7 @@ def test_charges(parser):
     parser.parse('tests/data/onetep/test20/test20.out', archive, None)
 
     sec_method = archive.run[0].method
-    assert sec_method[0].electronic_model[0].basis_set[0].cutoff.to('Ha').magnitude == approx(31.36667)
+    assert sec_method[0].electrons_representation[0].basis_set[0].cutoff.to('Ha').magnitude == approx(31.36667)
 
     sec_scc = archive.run[0].calculation
     assert len(sec_scc) == 1

--- a/tests/test_openmxparser.py
+++ b/tests/test_openmxparser.py
@@ -71,7 +71,7 @@ def test_HfO2(parser):
     scf[3].energy.sum_eigenvalues.value.magnitude == approx(-3.916702417016777e-16)
 
     method = run.method[0]
-    assert method.basis_set[0].type == 'numeric AOs'
+    assert method.electronic_model[0].basis_set[0].type == 'numeric AOs'
     assert method.electronic.n_spin_channels == 1
     assert method.electronic.method == 'DFT'
     assert method.electronic.smearing.width == approx(K_to_J(300))

--- a/tests/test_openmxparser.py
+++ b/tests/test_openmxparser.py
@@ -71,7 +71,7 @@ def test_HfO2(parser):
     scf[3].energy.sum_eigenvalues.value.magnitude == approx(-3.916702417016777e-16)
 
     method = run.method[0]
-    assert method.electronic_model[0].basis_set[0].type == 'numeric AOs'
+    assert method.electrons_representation[0].basis_set[0].type == 'numeric AOs'
     assert method.electronic.n_spin_channels == 1
     assert method.electronic.method == 'DFT'
     assert method.electronic.smearing.width == approx(K_to_J(300))

--- a/tests/test_orcaparser.py
+++ b/tests/test_orcaparser.py
@@ -45,9 +45,10 @@ def test_scf(parser):
     assert sec_method.x_orca_radial_grid_type == 'Gauss-Chebyshev'
     assert len(sec_method.dft.xc_functional.exchange) == 2
     assert sec_method.dft.xc_functional.correlation[0].name == 'GGA_C_LYP'
-    assert len(sec_method.basis_set) == 3
-    assert sec_method.basis_set[1].x_orca_basis_set == '11s6p2d1f'
-    assert sec_method.basis_set[2].x_orca_nb_of_primitive_gaussian_functions == 92
+    sec_basis = sec_method.electronic_model[0].basis_set
+    assert len(sec_basis) == 3
+    assert sec_basis[1].x_orca_basis_set == '11s6p2d1f'
+    assert sec_basis[2].x_orca_nb_of_primitive_gaussian_functions == 92
 
     sec_system = archive.run[0].system[0]
     assert sec_system.atoms.labels == ['C', 'O']

--- a/tests/test_orcaparser.py
+++ b/tests/test_orcaparser.py
@@ -45,7 +45,7 @@ def test_scf(parser):
     assert sec_method.x_orca_radial_grid_type == 'Gauss-Chebyshev'
     assert len(sec_method.dft.xc_functional.exchange) == 2
     assert sec_method.dft.xc_functional.correlation[0].name == 'GGA_C_LYP'
-    sec_basis = sec_method.electronic_model[0].basis_set
+    sec_basis = sec_method.electrons_representation[0].basis_set
     assert len(sec_basis) == 3
     assert sec_basis[1].x_orca_basis_set == '11s6p2d1f'
     assert sec_basis[2].x_orca_nb_of_primitive_gaussian_functions == 92

--- a/tests/test_psi4parser.py
+++ b/tests/test_psi4parser.py
@@ -44,7 +44,7 @@ def test_scf(parser):
 
     method = run.method[0]
     assert method.electronic.method == 'RHF'
-    sec_basis = method.electronic_model[0].basis_set
+    sec_basis = method.electrons_representation[0].basis_set
     assert len(sec_basis) == 1
     assert sec_basis[0].atom_centered[0].name == '6-31G**'
     assert sec_basis[0].atom_centered[0].x_psi4_n_shells == 12
@@ -120,13 +120,13 @@ def test_ecp_basis(parser):
 
     method = archive.run[0].method
     assert len(method) == 6
-    assert len(method[1].electronic_model[0].basis_set) == 2
-    sec_basis = method[2].electronic_model[0].basis_set
+    assert len(method[1].electrons_representation[0].basis_set) == 2
+    sec_basis = method[2].electrons_representation[0].basis_set
     assert sec_basis[0].atom_centered[0].name == 'DEF2-SV_P_'
     assert sec_basis[0].atom_centered[1].x_psi4_n_shells == 4
     assert sec_basis[1].atom_centered[0].name == 'DEF2-SV_P_ AUX'
     assert method[3].x_psi4_jk_matrices_parameters['Schwarz Cutoff'] == approx(1e-12)
-    sec_basis = method[4].electronic_model[0].basis_set
+    sec_basis = method[4].electrons_representation[0].basis_set
     assert sec_basis[1].atom_centered[0].n_basis_functions == 309
     assert method[5].electronic.method == 'RHF'
 
@@ -161,8 +161,8 @@ def test_dft_grad(parser):
     parser.parse('tests/data/psi4/dft-grad-disk/output.ref', archive, None)
 
     assert archive.run[-1].system[1].atoms.positions[0][2].magnitude == approx(-1.88056612e-11)
-    assert archive.run[-1].method[1].electronic_model[0].basis_set[0].atom_centered[0].name == 'AUG-CC-PVQZ'
-    assert archive.run[-1].method[0].electronic_model[0].basis_set[1].atom_centered[0].name == 'AUG-CC-PVQZ AUX'
+    assert archive.run[-1].method[1].electrons_representation[0].basis_set[0].atom_centered[0].name == 'AUG-CC-PVQZ'
+    assert archive.run[-1].method[0].electrons_representation[0].basis_set[1].atom_centered[0].name == 'AUG-CC-PVQZ AUX'
     assert archive.run[-1].calculation[1].forces.total.value[1][2].magnitude == approx(-8.16191049e-09)
 
 

--- a/tests/test_psi4parser.py
+++ b/tests/test_psi4parser.py
@@ -44,9 +44,10 @@ def test_scf(parser):
 
     method = run.method[0]
     assert method.electronic.method == 'RHF'
-    assert len(method.basis_set) == 1
-    assert method.basis_set[0].atom_centered[0].name == '6-31G**'
-    assert method.basis_set[0].atom_centered[0].x_psi4_n_shells == 12
+    sec_basis = method.electronic_model[0].basis_set
+    assert len(sec_basis) == 1
+    assert sec_basis[0].atom_centered[0].name == '6-31G**'
+    assert sec_basis[0].atom_centered[0].x_psi4_n_shells == 12
     assert method.scf.minimization_algorithm == 'PK'
     assert not method.scf.x_psi4_mom
     assert method.scf.threshold_energy_change.magnitude == approx(4.35974472e-26)
@@ -119,12 +120,14 @@ def test_ecp_basis(parser):
 
     method = archive.run[0].method
     assert len(method) == 6
-    assert len(method[1].basis_set) == 2
-    assert method[2].basis_set[0].atom_centered[0].name == 'DEF2-SV_P_'
-    assert method[2].basis_set[0].atom_centered[1].x_psi4_n_shells == 4
-    assert method[2].basis_set[1].atom_centered[0].name == 'DEF2-SV_P_ AUX'
+    assert len(method[1].electronic_model[0].basis_set) == 2
+    sec_basis = method[2].electronic_model[0].basis_set
+    assert sec_basis[0].atom_centered[0].name == 'DEF2-SV_P_'
+    assert sec_basis[0].atom_centered[1].x_psi4_n_shells == 4
+    assert sec_basis[1].atom_centered[0].name == 'DEF2-SV_P_ AUX'
     assert method[3].x_psi4_jk_matrices_parameters['Schwarz Cutoff'] == approx(1e-12)
-    assert method[4].basis_set[1].atom_centered[0].n_basis_functions == 309
+    sec_basis = method[4].electronic_model[0].basis_set
+    assert sec_basis[1].atom_centered[0].n_basis_functions == 309
     assert method[5].electronic.method == 'RHF'
 
     calc = archive.run[0].calculation
@@ -158,8 +161,8 @@ def test_dft_grad(parser):
     parser.parse('tests/data/psi4/dft-grad-disk/output.ref', archive, None)
 
     assert archive.run[-1].system[1].atoms.positions[0][2].magnitude == approx(-1.88056612e-11)
-    assert archive.run[-1].method[1].basis_set[0].atom_centered[0].name == 'AUG-CC-PVQZ'
-    assert archive.run[-1].method[0].basis_set[1].atom_centered[0].name == 'AUG-CC-PVQZ AUX'
+    assert archive.run[-1].method[1].electronic_model[0].basis_set[0].atom_centered[0].name == 'AUG-CC-PVQZ'
+    assert archive.run[-1].method[0].electronic_model[0].basis_set[1].atom_centered[0].name == 'AUG-CC-PVQZ AUX'
     assert archive.run[-1].calculation[1].forces.total.value[1][2].magnitude == approx(-8.16191049e-09)
 
 

--- a/tests/test_quantumespressoparser.py
+++ b/tests/test_quantumespressoparser.py
@@ -49,9 +49,14 @@ def test_scf(parser):
 
     sec_method = sec_run.method[0]
     assert len(sec_method.k_mesh.points) == 1
-    assert sec_method.basis_set[0].cell_dependent[0].name == 'PW_25.0'
-    assert sec_method.basis_set[1].cell_dependent[0].planewave_cutoff.magnitude == approx(2.17987236e-16,)
+    # basis set
+    sec_em = sec_method.electronic_model
+    assert sec_em[0].scope[0] == 'wavefunction'
+    assert sec_em[0].basis_set[0].cutoff.to('Ry').magnitude == approx(25.)
+    assert sec_em[1].scope[0] == 'density'
+    assert sec_em[1].basis_set[0].cutoff.to('Ry').magnitude == approx(100.)
     assert sec_method.x_qe_sticks_sum_G_smooth == 135043
+
     assert 'NL pseudopotentials' in sec_method.x_qe_allocated_array_name
     assert sec_method.x_qe_allocated_array_size[2] == 33554432.
     assert sec_method.x_qe_temporary_array_dimensions[3] == '262144,    8'

--- a/tests/test_quantumespressoparser.py
+++ b/tests/test_quantumespressoparser.py
@@ -50,7 +50,7 @@ def test_scf(parser):
     sec_method = sec_run.method[0]
     assert len(sec_method.k_mesh.points) == 1
     # basis set
-    sec_em = sec_method.electronic_model
+    sec_em = sec_method.electrons_representation
     assert sec_em[0].scope[0] == 'wavefunction'
     assert sec_em[0].basis_set[0].cutoff.to('Ry').magnitude == approx(25.)
     assert sec_em[1].scope[0] == 'density'

--- a/tests/test_turbomoleparser.py
+++ b/tests/test_turbomoleparser.py
@@ -43,7 +43,7 @@ def test_aoforce(parser):
     assert sec_method.electronic.method == 'DFT'
     assert sec_method.dft.xc_functional.correlation[0].name == 'GGA_C_P86'
     assert len(sec_method.atom_parameters) == 4
-    assert len(sec_method.basis_set[0].atom_centered) == 4
+    assert len(sec_method.electronic_model[0].basis_set[0].atom_centered) == 4
     assert sec_method.electronic.van_der_waals_method == 'DFT-D3'
     assert sec_method.x_turbomole_controlIn_scf_conv == 8
 
@@ -87,7 +87,7 @@ def test_grad_statpt_dscf(parser):
     parser.parse('tests/data/turbomole/acrolein_grad_statpt_dscf.out', archive, None)
 
     sec_methods = archive.run[0].method
-    assert sec_methods[0].basis_set[0].atom_centered[0].name == 'def2-SVP'
+    assert sec_methods[0].electronic_model[0].basis_set[0].atom_centered[0].name == 'def2-SVP'
     assert len(sec_methods) == 3
     assert sec_methods[0].dft.xc_functional.hybrid[0].name == 'HYB_GGA_XC_B3LYP'
 

--- a/tests/test_turbomoleparser.py
+++ b/tests/test_turbomoleparser.py
@@ -43,7 +43,7 @@ def test_aoforce(parser):
     assert sec_method.electronic.method == 'DFT'
     assert sec_method.dft.xc_functional.correlation[0].name == 'GGA_C_P86'
     assert len(sec_method.atom_parameters) == 4
-    assert len(sec_method.electronic_model[0].basis_set[0].atom_centered) == 4
+    assert len(sec_method.electrons_representation[0].basis_set[0].atom_centered) == 4
     assert sec_method.electronic.van_der_waals_method == 'DFT-D3'
     assert sec_method.x_turbomole_controlIn_scf_conv == 8
 
@@ -87,7 +87,7 @@ def test_grad_statpt_dscf(parser):
     parser.parse('tests/data/turbomole/acrolein_grad_statpt_dscf.out', archive, None)
 
     sec_methods = archive.run[0].method
-    assert sec_methods[0].electronic_model[0].basis_set[0].atom_centered[0].name == 'def2-SVP'
+    assert sec_methods[0].electrons_representation[0].basis_set[0].atom_centered[0].name == 'def2-SVP'
     assert len(sec_methods) == 3
     assert sec_methods[0].dft.xc_functional.hybrid[0].name == 'HYB_GGA_XC_B3LYP'
 

--- a/tests/test_vaspparser.py
+++ b/tests/test_vaspparser.py
@@ -73,7 +73,7 @@ def test_vasprunxml_static(parser):
     assert len(sec_method.dft.xc_functional.exchange) == 1
 
     # basis set
-    sec_basis_set = sec_method.electronic_model[0].basis_set
+    sec_basis_set = sec_method.electrons_representation[0].basis_set
     assert sec_basis_set[0].type == 'plane waves'
     assert sec_basis_set[0].scope == ['valence']
     assert sec_basis_set[0].cutoff.to('eV').magnitude == approx(512.2418)
@@ -131,7 +131,7 @@ def test_vasprunxml_relax(parser):
 
     # Check the basis set
     sec_method = sec_run.method[0]
-    sec_basis_set = sec_method.electronic_model[0].basis_set
+    sec_basis_set = sec_method.electrons_representation[0].basis_set
     assert sec_basis_set[0].type == 'plane waves'
     assert sec_basis_set[0].scope == ['valence']
     assert sec_basis_set[0].cutoff.to('eV').magnitude == approx(249.8)
@@ -240,7 +240,7 @@ def test_outcar(parser):
 
     sec_method = sec_run.method[0]
     # basis set
-    sec_basis_set = sec_method.electronic_model[0].basis_set
+    sec_basis_set = sec_method.electrons_representation[0].basis_set
     assert sec_basis_set[0].type == 'plane waves'
     assert sec_basis_set[0].scope == ['valence']
     assert sec_basis_set[0].cutoff.to('eV').magnitude == approx(520)

--- a/tests/test_vaspparser.py
+++ b/tests/test_vaspparser.py
@@ -72,6 +72,14 @@ def test_vasprunxml_static(parser):
     assert sec_method.x_vasp_incar_in['LCHARG']
     assert len(sec_method.dft.xc_functional.exchange) == 1
 
+    # basis set
+    assert sec_method.electron_model.basis_set[0].type == 'plane waves'
+    assert sec_method.electron_model.basis_set[0].scope == 'valence'
+    assert sec_method.electron_model.basis_set[0].cutoff.to('eV').magnitude == approx(512.2418)
+    assert sec_method.electron_model.basis_set[1].type == 'plane waves'
+    assert sec_method.electron_model.basis_set[1].scope == 'augmentation'
+    assert sec_method.electron_model.basis_set[1].cutoff.to('eV').magnitude == approx(429)
+
     sec_system = sec_run.system[-1]
     assert len(sec_system.atoms.labels) == 1
     assert sec_system.atoms.lattice_vectors[0][0].magnitude == approx(-1.78559323e-10)
@@ -119,6 +127,15 @@ def test_vasprunxml_relax(parser):
     k_mesh = sec_run.method[-1].k_mesh
     assert list(k_mesh.grid) == [16] * 3
     assert k_mesh.sampling_method == "Gamma-centered"
+
+    # Check the basis set
+    sec_method = sec_run.method[0]
+    assert sec_method.electron_model.basis_set[0].type == 'plane waves'
+    assert sec_method.electron_model.basis_set[0].scope == 'valence'
+    assert sec_method.electron_model.basis_set[0].cutoff.to('eV').magnitude == approx(249.8)
+    assert sec_method.electron_model.basis_set[1].type == 'plane waves'
+    assert sec_method.electron_model.basis_set[1].scope == 'augmentation'
+    assert sec_method.electron_model.basis_set[1].cutoff.to('eV').magnitude == approx(543.281)
 
     sec_sccs = archive.run[0].calculation
     assert len(sec_sccs) == 3
@@ -220,7 +237,14 @@ def test_outcar(parser):
     assert sec_run.program.version == '5.3.2 13Sep12 complex serial LinuxIFC'
 
     sec_method = sec_run.method[0]
-    assert sec_method.basis_set[0].cell_dependent[0].planewave_cutoff.magnitude == approx(8.3313185e-17)
+    # basis set
+    assert sec_method.electron_model.basis_set[0].type == 'plane waves'
+    assert sec_method.electron_model.basis_set[0].scope == 'valence'
+    assert sec_method.electron_model.basis_set[0].cutoff.to('eV').magnitude == approx(520)
+    assert sec_method.electron_model.basis_set[1].type == 'plane waves'
+    assert sec_method.electron_model.basis_set[1].scope == 'augmentation'
+    assert sec_method.electron_model.basis_set[1].cutoff.to('eV').magnitude == approx(543.3)
+    # DFT
     assert sec_method.dft.xc_functional.exchange[0].name == 'GGA_X_PBE'
     assert len(sec_method.atom_parameters) == 2
     assert sec_method.atom_parameters[1].pseudopotential_name == 'PAW_PBE'

--- a/tests/test_vaspparser.py
+++ b/tests/test_vaspparser.py
@@ -73,12 +73,13 @@ def test_vasprunxml_static(parser):
     assert len(sec_method.dft.xc_functional.exchange) == 1
 
     # basis set
-    assert sec_method.electron_model.basis_set[0].type == 'plane waves'
-    assert sec_method.electron_model.basis_set[0].scope == 'valence'
-    assert sec_method.electron_model.basis_set[0].cutoff.to('eV').magnitude == approx(512.2418)
-    assert sec_method.electron_model.basis_set[1].type == 'plane waves'
-    assert sec_method.electron_model.basis_set[1].scope == 'augmentation'
-    assert sec_method.electron_model.basis_set[1].cutoff.to('eV').magnitude == approx(429)
+    sec_basis_set = sec_method.electronic_model[0].basis_set
+    assert sec_basis_set[0].type == 'plane waves'
+    assert sec_basis_set[0].scope == ['valence']
+    assert sec_basis_set[0].cutoff.to('eV').magnitude == approx(512.2418)
+    assert sec_basis_set[1].type == 'plane waves'
+    assert sec_basis_set[1].scope == ['augmentation']
+    assert sec_basis_set[1].cutoff.to('eV').magnitude == approx(429)
 
     sec_system = sec_run.system[-1]
     assert len(sec_system.atoms.labels) == 1
@@ -130,12 +131,13 @@ def test_vasprunxml_relax(parser):
 
     # Check the basis set
     sec_method = sec_run.method[0]
-    assert sec_method.electron_model.basis_set[0].type == 'plane waves'
-    assert sec_method.electron_model.basis_set[0].scope == 'valence'
-    assert sec_method.electron_model.basis_set[0].cutoff.to('eV').magnitude == approx(249.8)
-    assert sec_method.electron_model.basis_set[1].type == 'plane waves'
-    assert sec_method.electron_model.basis_set[1].scope == 'augmentation'
-    assert sec_method.electron_model.basis_set[1].cutoff.to('eV').magnitude == approx(543.281)
+    sec_basis_set = sec_method.electronic_model[0].basis_set
+    assert sec_basis_set[0].type == 'plane waves'
+    assert sec_basis_set[0].scope == ['valence']
+    assert sec_basis_set[0].cutoff.to('eV').magnitude == approx(249.8)
+    assert sec_basis_set[1].type == 'plane waves'
+    assert sec_basis_set[1].scope == ['augmentation']
+    assert sec_basis_set[1].cutoff.to('eV').magnitude == approx(543.281)
 
     sec_sccs = archive.run[0].calculation
     assert len(sec_sccs) == 3
@@ -224,7 +226,7 @@ def test_dos_silicon(silicon_dos):
     gap = energies[lowest_unoccupied_index] - energies[highest_occupied_index]
     assert gap == approx(0.83140)
 
-    # Check that the no. valence electrons is receovered
+    # Check that the no. valence electrons is recovered
     dos_integrated = integrate_dos(dos, False, scc.energy.fermi)
     assert pytest.approx(dos_integrated, abs=1e-2) == 8.
 
@@ -238,12 +240,13 @@ def test_outcar(parser):
 
     sec_method = sec_run.method[0]
     # basis set
-    assert sec_method.electron_model.basis_set[0].type == 'plane waves'
-    assert sec_method.electron_model.basis_set[0].scope == 'valence'
-    assert sec_method.electron_model.basis_set[0].cutoff.to('eV').magnitude == approx(520)
-    assert sec_method.electron_model.basis_set[1].type == 'plane waves'
-    assert sec_method.electron_model.basis_set[1].scope == 'augmentation'
-    assert sec_method.electron_model.basis_set[1].cutoff.to('eV').magnitude == approx(543.3)
+    sec_basis_set = sec_method.electronic_model[0].basis_set
+    assert sec_basis_set[0].type == 'plane waves'
+    assert sec_basis_set[0].scope == ['valence']
+    assert sec_basis_set[0].cutoff.to('eV').magnitude == approx(520)
+    assert sec_basis_set[1].type == 'plane waves'
+    assert sec_basis_set[1].scope == ['augmentation']
+    assert sec_basis_set[1].cutoff.to('eV').magnitude == approx(543.3)
     # DFT
     assert sec_method.dft.xc_functional.exchange[0].name == 'GGA_X_PBE'
     assert len(sec_method.atom_parameters) == 2

--- a/tests/test_wien2kparser.py
+++ b/tests/test_wien2kparser.py
@@ -45,7 +45,7 @@ def test_single_point(parser, caplog):
     sec_method = archive.run[0].method[0]
     assert sec_method.dft.xc_functional.correlation[0].name == 'GGA_C_PBE_SOL'
     assert sec_method.x_wien2k_ifft[1] == 120
-    assert sec_method.x_wien2k_rkmax[2] == 4
+    #  assert sec_method.x_wien2k_rkmax[2] == 4
     assert sec_method.electronic.smearing.kind == 'tetrahedra'
     assert sec_method.x_wien2k_in2_espermin == 0.50
 

--- a/tests/test_wien2kparser.py
+++ b/tests/test_wien2kparser.py
@@ -45,7 +45,7 @@ def test_single_point(parser, caplog):
     sec_method = archive.run[0].method[0]
     assert sec_method.dft.xc_functional.correlation[0].name == 'GGA_C_PBE_SOL'
     assert sec_method.x_wien2k_ifft[1] == 120
-    assert sec_method.electronic_model[0].basis_set[0].cutoff_fractional == 7.0
+    assert sec_method.electrons_representation[0].basis_set[0].cutoff_fractional == 7.0
     assert sec_method.electronic.smearing.kind == 'tetrahedra'
     assert sec_method.x_wien2k_in2_espermin == 0.50
 

--- a/tests/test_wien2kparser.py
+++ b/tests/test_wien2kparser.py
@@ -45,7 +45,7 @@ def test_single_point(parser, caplog):
     sec_method = archive.run[0].method[0]
     assert sec_method.dft.xc_functional.correlation[0].name == 'GGA_C_PBE_SOL'
     assert sec_method.x_wien2k_ifft[1] == 120
-    #  assert sec_method.x_wien2k_rkmax[2] == 4
+    assert sec_method.electronic_model[0].basis_set[0].cutoff_fractional == 7.0
     assert sec_method.electronic.smearing.kind == 'tetrahedra'
     assert sec_method.x_wien2k_in2_espermin == 0.50
 


### PR DESCRIPTION
Applies the updated `BasisSet` metainfo introduced in https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/1264.
Heavily extends the LAPW basis sets in _exciting_, fleur, wien2k (but not elk).