### PR TITLE
Pseudo vasp

### DIFF
--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -1314,8 +1314,9 @@ class VASPParser():
                 sec_method_atom_kind.mass = pseudopotential['number']['POMASS'] * ureg.amu
                 sec_method_atom_kind.n_valence_electrons = pseudopotential['number']['ZVAL']
                 pp = Pseudopotential()
-                pp.type = 'PAW' if pseudopotential['flag']['LPAW'] else 'USPP'  # TODO check if this is correct
-                pp.norm_conserving = False
+                pp.type = 'PAW'
+                if pseudopotential['flag']['LULTRA']:
+                    pp.type = 'USPP'  # TODO check if this is correct
                 pp.cutoff = pseudopotential['number']['ENMAX'] * ureg.eV
                 pp.xc_functional_name = self.parser.xc_functional_mapping.get(
                     pseudopotential['title'][0].split('_')[1], ['GGA_X_PBE', 'GGA_C_PBE'])

--- a/tests/test_vaspparser.py
+++ b/tests/test_vaspparser.py
@@ -228,6 +228,15 @@ def test_outcar(parser):
     k_mesh = sec_method.k_mesh
     assert len(k_mesh.points) == 145
 
+    sec_atom_param = sec_method.atom_parameters[0]
+    assert sec_atom_param.n_valence_electrons == approx(11.0)
+    assert sec_atom_param.mass.to('amu').magnitude == approx(227.028)
+
+    sec_pseudo = sec_atom_param.pseudopotential
+    assert sec_pseudo.name == 'PAW_PBE Ac 06Sep2000'
+    assert sec_pseudo.xc_functional_name == ['GGA_X_PBE', 'GGA_C_PBE']
+    assert sec_pseudo.cutoff.to('eV').magnitude == approx(172.237)
+
     sec_system = sec_run.system[0]
     assert sec_system.atoms.lattice_vectors[1][0].magnitude == approx(3.141538e-10)
     assert sec_system.atoms.positions[1][0].magnitude == approx(3.14154e-10)

--- a/tests/test_vaspparser.py
+++ b/tests/test_vaspparser.py
@@ -70,7 +70,6 @@ def test_vasprunxml_static(parser):
     assert len(sec_method.x_vasp_incar_in) == 27
     assert len(sec_method.x_vasp_incar_out) == 112
     assert sec_method.x_vasp_incar_in['LCHARG']
-    assert sec_method.atom_parameters[0].mass.magnitude == approx(4.0359402e-26)
     assert len(sec_method.dft.xc_functional.exchange) == 1
 
     sec_system = sec_run.system[-1]


### PR DESCRIPTION
Add extraction of the VASP pseudopotential to the metainfo introduced in https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/1260
Files to consider are `OUTCAR` or `POTCAR` (in case of `vasprun.xml`).