### PR TITLE
EDMFT parser

### DIFF
--- a/electronicparsers/edmft/__init__.py
+++ b/electronicparsers/edmft/__init__.py
@@ -1,0 +1,19 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD.
+# See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .parser import EDMFTParser

--- a/electronicparsers/edmft/__main__.py
+++ b/electronicparsers/edmft/__main__.py
@@ -1,0 +1,31 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD.
+# See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import sys
+import json
+import logging
+
+from nomad.utils import configure_logging
+from nomad.datamodel import EntryArchive
+from electronicparsers.edmft import EDMFTParser
+
+if __name__ == "__main__":
+    configure_logging(console_log_level=logging.DEBUG)
+    archive = EntryArchive()
+    EDMFTParser().parse(sys.argv[1], archive, logging)
+    json.dump(archive.m_to_dict(), sys.stdout, indent=2)

--- a/electronicparsers/edmft/metainfo/__init__.py
+++ b/electronicparsers/edmft/metainfo/__init__.py
@@ -1,0 +1,24 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD.
+# See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from nomad.metainfo import Environment
+
+from . import edmft
+
+m_env = Environment()
+m_env.m_add_sub_section(Environment.packages, edmft.m_package)

--- a/electronicparsers/edmft/metainfo/edmft.py
+++ b/electronicparsers/edmft/metainfo/edmft.py
@@ -1,0 +1,48 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD.
+# See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import numpy as np
+
+from nomad.metainfo import (  # pylint: disable=unused-import
+    MSection, Package, Quantity, Section, SubSection, JSON
+)
+from nomad.datamodel.metainfo import simulation
+
+
+m_package = Package()
+
+
+class Method(simulation.method.Method):
+    '''
+    Section containing the various parameters that define the theory and the
+    approximations (convergence, thresholds, etc.) behind the calculation.
+    '''
+
+    m_def = Section(validate=False, extends_base_section=True)
+
+    x_edmft_general_parameters = Quantity(
+        type=JSON,
+        description='''
+        General input parameters for the calculation.
+        ''')
+
+    x_edmft_impurity_solver_parameters = Quantity(
+        type=JSON,
+        description='''
+        Impurity solver parameters as defined in the dictionary 'iparams0'.
+        ''')

--- a/electronicparsers/edmft/nomad_plugin.yaml
+++ b/electronicparsers/edmft/nomad_plugin.yaml
@@ -1,0 +1,45 @@
+code_category: Atomistic code
+code_homepage: http://hauleweb.rutgers.edu/tutorials/
+code_name: eDMFT
+metadata:
+  codeCategory: Atomistic code
+  codeLabel: eDMFT
+  codeLabelStyle: DMFT in capitals, the rest in lowercase
+  codeName: eDMFT
+  codeUrl: http://hauleweb.rutgers.edu/tutorials/
+  codeVersion: ''
+  parserDirName: dependencies/parsers/electronic/electronicparsers/edmft/
+  parserGitUrl: https://github.com/nomad-coe/electronic-parsers.git
+  parserSpecific: ''
+  preamble: ''
+  status: production
+  tableOfFiles: '| Input Filename | Description |
+
+    | --- | --- |
+
+    | `*.indmfl` | **Mainfile:** input DMFT parameters file |
+
+    | `*params.dat` | input text file with input parameters |
+
+    | `*.struct` | output text file with data for the structure (specific to WIEN2k) |
+
+    | `*.indmf*` | output text file with various inputs for DMFT |
+
+    | `*.in*` | output text file with various inputs for DFT and sfc calculation |
+
+    | `*.clm*` | output data file with charge densities |
+
+    | `*.klist` | output data file with K point list |
+
+    | `*.kgen` | output data file with K generation |
+
+    | `*.scf*` | output text file with info about the sfc cycles |
+
+    | `*projectorw.dat` | output data file with projectors |
+
+    | `*sig.inp*` | output data file with sigma |
+
+    '
+name: parsers/edmft
+parser_class_name: electronicparsers.edmft.parser.EDMFTParser
+python_package: electronicparsers.edmft

--- a/electronicparsers/edmft/parser.py
+++ b/electronicparsers/edmft/parser.py
@@ -1,0 +1,196 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD.
+# See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import numpy as np
+import os
+import logging
+import h5py
+import re
+
+from nomad.units import ureg
+from nomad.parsing.file_parser import TextParser, Quantity
+from nomad.datamodel.metainfo.simulation.run import Run, Program
+from nomad.datamodel.metainfo.simulation.system import System, Atoms
+from nomad.datamodel.metainfo.simulation.method import (
+    Method, HubbardKanamoriModel, LatticeModelHamiltonian, KMesh, FrequencyMesh, TimeMesh,
+    DMFT
+)
+from nomad.datamodel.metainfo.simulation.calculation import (
+    Calculation, ScfIteration, Energy, GreensFunctions
+)
+from nomad.datamodel.metainfo.simulation.workflow import SinglePoint
+from ..utils import get_files
+from ..wien2k.parser import StructParser
+
+
+class IndmflParser(TextParser):
+    def __init__(self):
+        super().__init__()
+
+    def init_quantities(self):
+        self._quantities = [
+            Quantity(
+                'version',
+                r'LABEL\d+\:\s*using WIEN2k_(\S+) \(Release ([\d\/]+)\)', flatten=False)]
+
+
+class ParamsParser(TextParser):
+    def __init__(self):
+        super().__init__()
+
+    def init_quantities(self):
+        self._quantities = [
+            Quantity(
+                'general_parameters', r'([\s\S]+)(?:\# Impurity problem number 0)',
+                sub_parser=TextParser(quantities=[
+                    Quantity(
+                        'params', r'([a-zA-Z\_]+)\s*\=\s*\'*([a-zA-Z\d\.\-]+)\'*',
+                        repeats=True)
+                    ])
+                ),
+            Quantity(
+                'impurity_parameters', r'iparams0\=([\s\S]+)(?:\s*\})',
+                sub_parser=TextParser(quantities=[
+                    Quantity(
+                        'params',
+                        r'\s*\"(.+)\"\s*\:\s*\[[\"\'\s]*([a-zA-Z\d\.\-]+)[\"\'\s]*\,',
+                        repeats=True)
+                    ])
+                )]
+
+
+class EDMFTParser:
+    level = 1
+
+    def __init__(self):
+        self._re_namesafe = re.compile(r'[^\w]')
+        self._calculation_type = 'dmft'
+
+        self.struct_parser = StructParser()
+        self.indmfl_parser = IndmflParser()
+        self.params_parser = ParamsParser()
+
+        self._solver_map = {
+            'CTQMC': 'CT-HYB',
+            'OCA': 'OCA'
+        }
+
+    def parse_system(self):
+        struct_file = get_files('*.struct', self.filepath, self.mainfile)
+        if struct_file:
+            if len(struct_file) > 1:
+                self.logger.warning('Multiple *struct files found; we will parse the last one!')
+            self.struct_parser.mainfile = struct_file[-1]
+            atoms = self.struct_parser.get_atoms()
+            if atoms is None:
+                return
+
+            sec_system = self.archive.run[-1].m_create(System)
+            sec_atoms = sec_system.m_create(Atoms)
+            sec_atoms.lattice_vectors = np.array(atoms.get_cell()) * ureg.angstrom
+            sec_atoms.positions = atoms.get_positions() * ureg.angstrom
+            sec_atoms.labels = atoms.get_chemical_symbols()
+            sec_atoms.periodic = atoms.get_pbc()
+
+    def parse_initial_model(self):
+        '''
+        for n in range(data.attrs.get('general.nat', 1)):
+            sec_hubbard_kanamori_model = sec_hamiltonian.m_create(HubbardKanamoriModel)
+
+            angular_momentum = 'd'
+            sec_hubbard_kanamori_model.orbital = angular_momentum
+            sec_hubbard_kanamori_model.double_counting_correction = data.attrs.get('general.dc', None)
+            # w2dynamics keeps spin-rotational invariance
+            for key in self._hubbard_kanamori_map.keys():
+                parameters = data.attrs.get(f'atoms.{n+1}.{key}{angular_momentum}{angular_momentum}', None) * ureg.eV
+                setattr(sec_hubbard_kanamori_model, self._hubbard_kanamori_map.get(key), parameters)
+
+            if data.attrs.get(f'atoms.{n+1}.hamiltonian') == 'Density':
+                sec_hubbard_kanamori_model.j = 0.0
+            elif data.attrs.get(f'atoms.{n+1}.hamiltonian') == 'Kanamori':
+                sec_hubbard_kanamori_model.j = sec_hubbard_kanamori_model.jh
+        '''
+
+    def parse_method(self):
+        sec_run = self.archive.run[-1]
+
+        def parse_hubbard_model(method, gen_params, imp_params):
+            pass
+
+        def parse_dmft(method, gen_params, imp_params):
+            sec_dmft = method.m_create(DMFT)
+            sec_dmft.inverse_temperature = imp_params.get('beta') / ureg.eV
+            sec_dmft.impurity_solver = self._solver_map.get(gen_params.get('solver'))
+
+        def parse_meshes(method):
+            pass
+
+        params_file = get_files('*params.dat', self.filepath, self.mainfile)
+        if params_file:
+            if len(params_file) > 1:
+                self.logger.warning('Multiple *params.dat files found; we will parse the last one!')
+            self.params_parser.mainfile = params_file[-1]
+
+            gen_parameters = dict(self.params_parser.get('general_parameters', {}).get('params', []))
+            imp_parameters = dict(self.params_parser.get('impurity_parameters', {}).get('params', []))
+
+            sec_method = sec_run.m_create(Method)
+            sec_method.x_edmft_general_parameters = gen_parameters
+            sec_method.x_edmft_impurity_solver_parameters = imp_parameters
+            if gen_parameters and imp_parameters:
+                parse_hubbard_model(sec_method, gen_parameters, imp_parameters)
+                parse_dmft(sec_method, gen_parameters, imp_parameters)
+                parse_meshes(sec_method)
+
+    def parse_scc(self):
+        pass
+
+    def init_parser(self):
+        self.struct_parser.mainfile = None
+        self.struct_parser.logger = self.logger
+        self.indmfl_parser.mainfile = self.mainfile
+        self.indmfl_parser.logger = self.logger
+        self.params_parser.mainfile = None
+        self.params_parser.logger = self.logger
+
+    def parse(self, filepath, archive, logger):
+        self.filepath = filepath
+        self.archive = archive
+        self.maindir = os.path.dirname(self.filepath)
+        self.mainfile = os.path.basename(self.filepath)
+        self.logger = logging.getLogger(__name__) if logger is None else logger
+
+        self.init_parser()
+
+        # Program section
+        sec_run = self.archive.m_create(Run)
+        sec_run.program = Program(name='eDMFT')
+
+        # System section
+        self.parse_system()
+
+        # Method.DMFT section
+        self.parse_initial_model()
+        self.parse_method()
+
+        # Calculation section
+        self.parse_scc()
+
+        # Workflow section
+        workflow = SinglePoint()
+        self.archive.workflow2 = workflow

--- a/electronicparsers/soliddmft/nomad_plugin.yaml
+++ b/electronicparsers/soliddmft/nomad_plugin.yaml
@@ -3,9 +3,9 @@ code_homepage: https://github.com/TRIQS/solid_dmft
 code_name: soliddmft
 metadata:
   codeCategory: Atomistic code
-  codeLabel: soliddmft
+  codeLabel: solid_dmft
   codeLabelStyle: All in lowercase
-  codeName: solid_dmft
+  codeName: soliddmft
   codeUrl: https://github.com/TRIQS/solid_dmft
   codeVersion: ''
   parserDirName: dependencies/parsers/electronic/electronicparsers/soliddmft/
@@ -22,6 +22,6 @@ metadata:
     |
 
     '
-name: parsers/solid_dmft
+name: parsers/soliddmft
 parser_class_name: electronicparsers.soliddmft.parser.SolidDMFTParser
 python_package: electronicparsers.soliddmft

--- a/electronicparsers/w2dynamics/parser.py
+++ b/electronicparsers/w2dynamics/parser.py
@@ -206,8 +206,6 @@ class W2DynamicsParser:
             elif data.attrs.get(f'atoms.{n+1}.hamiltonian') == 'Kanamori':
                 sec_hubbard_kanamori_model.j = sec_hubbard_kanamori_model.jh
 
-            sec_hubbard_kanamori_model.double_counting_correction = data.attrs.get('general.dc')
-
     def parse_method(self, data):
         """Parses DMFT and code-specific metadata from `.config` in the hdf5 mainfile
 


### PR DESCRIPTION
PR for adding EDMFT parser. This is a DFT+DMFT parser for which:

- [ ] Parse text quantities using the new `write_to_archive` method.
- [ ] Use DMFT workflow from #104 
- [ ] Extend the metainfo for spectral functions and real space Green's function quantities.