### PR TITLE
Fix broken command settings Gaussian parser

### DIFF
--- a/electronicparsers/gaussian/parser.py
+++ b/electronicparsers/gaussian/parser.py
@@ -314,7 +314,7 @@ class GaussianOutParser(TextParser):
                 'x_gaussian_settings_corrected',
                 r'\-{10}\s*(#[\s\S]+?)\-{10}',
                 convert=False,
-                str_operation=lambda x: x.strip().replace('\n', '')),
+                str_operation=lambda x: re.sub(r'\s*\n\s*', '', x).strip()),
             Quantity(
                 'charge', r'Charge =\s*([\-\+\d]+)', dtype=int),
             Quantity(

--- a/electronicparsers/gaussian/parser.py
+++ b/electronicparsers/gaussian/parser.py
@@ -314,7 +314,7 @@ class GaussianOutParser(TextParser):
                 'x_gaussian_settings_corrected',
                 r'\-{10}\s*(#[\s\S]+?)\-{10}',
                 convert=False,
-                str_operation=lambda x: re.sub(r'\s*\n\s*', '', x).strip()),
+                str_operation=lambda x: re.sub(r'\s*\n\s*', '', x).strip()),  # when x_gaussian_settings_corrected is no longer stored, `strip()` can be removed
             Quantity(
                 'charge', r'Charge =\s*([\-\+\d]+)', dtype=int),
             Quantity(


### PR DESCRIPTION
The Gaussian input commands were split with additional whitespaces at newlines.
This led to the incorrect quantity of `s=128`, where the former part was interpreted as `LDA_X` by `resolve_xc_functional`.

These redundant whitespaces are now trimmed.

Closes #120 