### PR TITLE
131 fhi aims unclear extraction of species

### DIFF
--- a/electronicparsers/fhiaims/metainfo/fhi_aims.py
+++ b/electronicparsers/fhiaims/metainfo/fhi_aims.py
@@ -192,75 +192,6 @@ class x_fhi_aims_section_controlIn_basis_set(MSection):
         repeats=True)
 
 
-class x_fhi_aims_section_controlInOut_atom_species(MSection):
-    '''
-    -
-    '''
-
-    m_def = Section(validate=False)
-
-    x_fhi_aims_controlInOut_pure_gaussian = Quantity(
-        type=str,
-        shape=[],
-        description='''
-        -
-        ''')
-
-    x_fhi_aims_controlInOut_species_charge = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        unit='coulomb',
-        description='''
-        -
-        ''')
-
-    x_fhi_aims_controlInOut_species_cut_pot_scale = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        description='''
-        -
-        ''')
-
-    x_fhi_aims_controlInOut_species_cut_pot_width = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        unit='meter',
-        description='''
-        -
-        ''')
-
-    x_fhi_aims_controlInOut_species_cut_pot = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        unit='meter',
-        description='''
-        -
-        ''')
-
-    x_fhi_aims_controlInOut_species_mass = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        unit='kilogram',
-        description='''
-        -
-        ''')
-
-    x_fhi_aims_controlInOut_species_name = Quantity(
-        type=str,
-        shape=[],
-        description='''
-        -
-        ''')
-
-    x_fhi_aims_section_controlInOut_basis_func = SubSection(
-        sub_section=SectionProxy('x_fhi_aims_section_controlInOut_basis_func'),
-        repeats=True)
-
-    x_fhi_aims_section_vdW_TS = SubSection(
-        sub_section=SectionProxy('x_fhi_aims_section_vdW_TS'),
-        repeats=True)
-
-
 class x_fhi_aims_section_controlInOut_basis_func(MSection):
     '''
     -
@@ -1386,8 +1317,38 @@ class AtomParameters(simulation.method.AtomParameters):
 
     m_def = Section(validate=False, extends_base_section=True)
 
-    x_fhi_aims_section_controlInOut_atom_species = SubSection(
-        sub_section=SectionProxy('x_fhi_aims_section_controlInOut_atom_species'),
+    x_fhi_aims_controlInOut_pure_gaussian = Quantity(
+        type=str,
+        shape=[],
+        description='''
+        -
+        ''')
+
+    x_fhi_aims_controlInOut_species_cut_pot_scale = Quantity(
+        type=np.dtype(np.float64),
+        shape=[],
+        description='''
+        -
+        ''')
+
+    x_fhi_aims_controlInOut_species_cut_pot_width = Quantity(
+        type=np.dtype(np.float64),
+        shape=[],
+        unit='meter',
+        description='''
+        -
+        ''')
+
+    x_fhi_aims_controlInOut_species_cut_pot = Quantity(
+        type=np.dtype(np.float64),
+        shape=[],
+        unit='meter',
+        description='''
+        -
+        ''')
+
+    x_fhi_aims_section_vdW_TS = SubSection(
+        sub_section=SectionProxy('x_fhi_aims_section_vdW_TS'),
         repeats=True)
 
 

--- a/electronicparsers/fhiaims/metainfo/fhi_aims.py
+++ b/electronicparsers/fhiaims/metainfo/fhi_aims.py
@@ -1351,6 +1351,12 @@ class AtomParameters(simulation.method.AtomParameters):
         sub_section=SectionProxy('x_fhi_aims_section_vdW_TS'),
         repeats=True)
 
+    x_fhi_aims_section_controlIn_basis_set = Quantity(
+        type=Reference(SectionProxy('x_fhi_aims_section_controlIn_basis_set')),
+        shape=[],
+        description='''-''',
+    )
+
 
 class HubbardKanamoriModel(simulation.method.HubbardKanamoriModel):
 

--- a/electronicparsers/fhiaims/metainfo/fhi_aims.py
+++ b/electronicparsers/fhiaims/metainfo/fhi_aims.py
@@ -187,6 +187,13 @@ class x_fhi_aims_section_controlIn_basis_set(MSection):
         -
         ''')
 
+    x_fhi_aims_controlIn_hash = Quantity(
+        type=str,
+        shape=[],
+        description='''
+        -
+        ''')
+
     x_fhi_aims_section_controlIn_basis_func = SubSection(
         sub_section=SectionProxy('x_fhi_aims_section_controlIn_basis_func'),
         repeats=True)

--- a/electronicparsers/fhiaims/metainfo/fhi_aims.py
+++ b/electronicparsers/fhiaims/metainfo/fhi_aims.py
@@ -88,6 +88,30 @@ class x_fhi_aims_section_controlIn_basis_func(MSection):
         -
         ''')
 
+    x_fhi_aims_controlIn_basis_func_gauss_l = Quantity(
+        type=np.dtype(np.int32),
+        shape=[],
+        description='''
+        "L is an integer number, specifying the angular momentum"
+        - Manual FHI-aims v201716_2
+        ''')
+
+    x_fhi_aims_controlIn_basis_func_gauss_alphas = Quantity(
+        type=np.dtype(np.float64),
+        shape=['*'],
+        unit='1 / meter ** 2',
+        description='''
+        "The exponent defining a (primitive) Gaussian function"
+        - Manual FHI-aims v201716_2
+        ''')
+
+    x_fhi_aims_controlIn_basis_func_gauss_coeffs = Quantity(
+        type=np.dtype(np.float64),
+        shape=['*'],
+        description='''
+        Weights in linearly composed Gaussian functions.
+        ''')
+
     x_fhi_aims_controlIn_basis_func_type = Quantity(
         type=str,
         shape=[],
@@ -145,20 +169,6 @@ class x_fhi_aims_section_controlIn_basis_set(MSection):
         angular leven for the hartreee part
         ''')
 
-    x_fhi_aims_controlIn_mass = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        description='''
-        mass of the nucleus in atomic mass units
-        ''')
-
-    x_fhi_aims_controlIn_nucleus = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        description='''
-        charge of the nucleus
-        ''')
-
     x_fhi_aims_controlIn_outer_grid = Quantity(
         type=np.dtype(np.float64),
         shape=[],
@@ -180,14 +190,14 @@ class x_fhi_aims_section_controlIn_basis_set(MSection):
         radial multiplier
         ''')
 
-    x_fhi_aims_controlIn_species_name = Quantity(
+    x_fhi_aims_controlIn_hash = Quantity(
         type=str,
         shape=[],
         description='''
         -
         ''')
 
-    x_fhi_aims_controlIn_hash = Quantity(
+    x_fhi_aims_controlIn_species_name = Quantity(
         type=str,
         shape=[],
         description='''
@@ -213,73 +223,8 @@ class x_fhi_aims_section_controlInOut_basis_func(MSection):
         -
         ''')
 
-    x_fhi_aims_controlInOut_basis_func_gauss_alpha = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        unit='1 / meter ** 2',
-        description='''
-        -
-        ''')
-
-    x_fhi_aims_controlInOut_basis_func_gauss_l = Quantity(
-        type=np.dtype(np.int32),
-        shape=[],
-        description='''
-        -
-        ''')
-
-    x_fhi_aims_controlInOut_basis_func_gauss_N = Quantity(
-        type=np.dtype(np.int32),
-        shape=[],
-        description='''
-        -
-        ''')
-
-    x_fhi_aims_controlInOut_basis_func_gauss_weight = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        description='''
-        -
-        ''')
-
-    x_fhi_aims_controlInOut_basis_func_l = Quantity(
-        type=str,
-        shape=[],
-        description='''
-        -
-        ''')
-
-    x_fhi_aims_controlInOut_basis_func_n = Quantity(
-        type=np.dtype(np.int32),
-        shape=[],
-        description='''
-        -
-        ''')
-
     x_fhi_aims_controlInOut_basis_func_occ = Quantity(
         type=np.dtype(np.float64),
-        shape=[],
-        description='''
-        -
-        ''')
-
-    x_fhi_aims_controlInOut_basis_func_primitive_gauss_alpha = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        unit='1 / meter ** 2',
-        description='''
-        -
-        ''')
-
-    x_fhi_aims_controlInOut_basis_func_radius = Quantity(
-        type=np.dtype(np.float64),
-        shape=[],
-        description='''
-        -
-        ''')
-
-    x_fhi_aims_controlInOut_basis_func_type = Quantity(
-        type=str,
         shape=[],
         description='''
         -

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -53,7 +53,7 @@ from .metainfo.fhi_aims import Run as xsection_run, Method as xsection_method,\
     x_fhi_aims_section_controlIn_basis_set, x_fhi_aims_section_controlIn_basis_func,\
     x_fhi_aims_section_vdW_TS
 
-from ..utils import BeyondDFTWorkflowsParser
+from ..utils import BeyondDFTWorkflowsParser, get_basis_hash
 
 
 re_float = r'[-+]?\d+\.\d*(?:[Ee][-+]\d+)?'
@@ -1564,6 +1564,9 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
             if division is not None:
                 sec_basis_set.x_fhi_aims_controlIn_number_of_basis_func = len(division)
                 sec_basis_set.x_fhi_aims_controlIn_division = division
+
+            # store hash
+            sec_basis_set.x_fhi_aims_controlIn_hash = get_basis_hash([sec_basis_set], [True])
 
         def _get_elemental_tier(
                 basis_settings: x_fhi_aims_section_controlIn_basis_set,

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -1739,6 +1739,8 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
 
         def parse_atom_type(species):
             sec_atom_type = sec_method.m_create(AtomParameters)
+            param_index = len(sec_method.atom_parameters) - 1
+            sec_atom_type.x_fhi_aims_section_controlIn_basis_set = sec_method.x_fhi_aims_section_controlIn_basis_set[param_index]
             for key, val in species.items():
                 if key == 'nuclear charge':
                     sec_atom_type.charge = val[0] * ureg.elementary_charge

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -51,7 +51,6 @@ from nomad.datamodel.metainfo.simulation.workflow import (
 from .metainfo.fhi_aims import Run as xsection_run, Method as xsection_method,\
     x_fhi_aims_section_parallel_task_assignement, x_fhi_aims_section_parallel_tasks,\
     x_fhi_aims_section_controlIn_basis_set, x_fhi_aims_section_controlIn_basis_func,\
-    x_fhi_aims_section_controlInOut_atom_species, x_fhi_aims_section_controlInOut_basis_func,\
     x_fhi_aims_section_vdW_TS
 
 from ..utils import BeyondDFTWorkflowsParser
@@ -790,7 +789,7 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
             'Hybrid M11 gradient-corrected functionals': [{'name': 'MGGA_C_M11'}, {'name': 'HYB_MGGA_X_M11'}]}
 
         # TODO update metainfo to reflect all energy corrections
-        # why section_vdW_TS under x_fhi_aims_section_controlInOut_atom_species?
+        # why section_vdW_TS under atom_parameter?
         self._energy_map = {
             'Total energy uncorrected': 'energy_total',
             'Total energy corrected': 'energy_total_t0',
@@ -1290,7 +1289,6 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
         def parse_vdW(section):
             # these are not actually vdW outputs but vdW control parameters but are
             # printed within the calculation section.
-            # TODO why is x_fhi_aims_section_vdW_TS under x_fhi_aims_section_controlInOut_atom_species
             # we would then have to split the vdW parameters by species
             atoms = section.get('vdW_TS', {}).get('atom_hirshfeld', [])
             if not atoms:
@@ -1303,8 +1301,7 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
             for sec in sec_atom_type:
                 for atom in atoms:
                     if sec.label == atom['atom']:
-                        sec_vdW_ts = sec.x_fhi_aims_section_controlInOut_atom_species[-1].m_create(
-                            x_fhi_aims_section_vdW_TS)
+                        sec_vdW_ts = sec.m_create(x_fhi_aims_section_vdW_TS)
                         for key, val in atom.items():
                             metainfo_name = self._property_map.get(key, None)
                             if metainfo_name is None:
@@ -1742,26 +1739,19 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
 
         def parse_atom_type(species):
             sec_atom_type = sec_method.m_create(AtomParameters)
-            sec_atom_species = sec_atom_type.m_create(
-                x_fhi_aims_section_controlInOut_atom_species)
             for key, val in species.items():
                 if key == 'nuclear charge':
-                    charge = val[0] * ureg.elementary_charge
-                    sec_atom_type.charge = charge
-                    sec_atom_species.x_fhi_aims_controlInOut_species_charge = charge
+                    sec_atom_type.charge = val[0] * ureg.elementary_charge
                 elif key == 'atomic mass':
-                    mass = val[0][0] * ureg.amu
-                    sec_atom_type.mass = mass
-                    sec_atom_species.x_fhi_aims_controlInOut_species_mass = mass
+                    sec_atom_type.mass = val[0][0] * ureg.amu
                 elif key == 'species':
                     sec_atom_type.label = val
-                    sec_atom_species.x_fhi_aims_controlInOut_species_name = val
                 elif 'request to include pure gaussian fns' in key:
-                    sec_atom_species.x_fhi_aims_controlInOut_pure_gaussian = val[0]
+                    sec_atom_type.x_fhi_aims_controlInOut_pure_gaussian = val[0]
                 elif 'cutoff potl' in key:
-                    sec_atom_species.x_fhi_aims_controlInOut_species_cut_pot = val[0][0] * ureg.angstrom
-                    sec_atom_species.x_fhi_aims_controlInOut_species_cut_pot_width = val[0][1] * ureg.angstrom
-                    sec_atom_species.x_fhi_aims_controlInOut_species_cut_pot_scale = val[0][2]
+                    sec_atom_type.x_fhi_aims_controlInOut_species_cut_pot = val[0][0] * ureg.angstrom
+                    sec_atom_type.x_fhi_aims_controlInOut_species_cut_pot_width = val[0][1] * ureg.angstrom
+                    sec_atom_type.x_fhi_aims_controlInOut_species_cut_pot_scale = val[0][2]
                 elif "request for '+U'" in key:
                     sec_hubbard = sec_atom_type.m_create(HubbardKanamoriModel)
                     sec_hubbard.orbital = f'{val[0][0]}{val[0][1]}'
@@ -1769,47 +1759,8 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
                     sec_hubbard.double_counting_correction = 'Dudarev'
                     sec_hubbard.x_fhi_aims_projection_type = 'Mulliken (dual)'
                     sec_hubbard.x_fhi_aims_petukhov_mixing_factor = self.out_parser.get('petukhov')
-                elif 'free-atom' in key or 'free-ion' in key:
-                    for i in range(len(val)):
-                        sec_basis_func = sec_atom_species.m_create(
-                            x_fhi_aims_section_controlInOut_basis_func)
-                        sec_basis_func.x_fhi_aims_controlInOut_basis_func_type = ' '.join(key.split()[:-1])
-                        sec_basis_func.x_fhi_aims_controlInOut_basis_func_n = val[i][0]
-                        sec_basis_func.x_fhi_aims_controlInOut_basis_func_l = val[i][1]
-                        sec_basis_func.x_fhi_aims_controlInOut_basis_func_occ = val[i][2]
-                elif 'hydrogenic' in key:
-                    for i in range(len(val)):
-                        sec_basis_func = sec_atom_species.m_create(
-                            x_fhi_aims_section_controlInOut_basis_func)
-                        sec_basis_func.x_fhi_aims_controlInOut_basis_func_type = ' '.join(key.split()[:-1])
-                        sec_basis_func.x_fhi_aims_controlInOut_basis_func_n = val[i][0]
-                        sec_basis_func.x_fhi_aims_controlInOut_basis_func_l = val[i][1]
-                        sec_basis_func.x_fhi_aims_controlInOut_basis_func_eff_charge = val[i][2]
-                elif 'ionic' in key:
-                    for i in range(len(val)):
-                        sec_basis_func = sec_atom_species.m_create(
-                            x_fhi_aims_section_controlInOut_basis_func)
-                        sec_basis_func.x_fhi_aims_controlInOut_basis_func_type = 'ionic basis'
-                        sec_basis_func.x_fhi_aims_controlInOut_basis_func_n = val[i][0]
-                        sec_basis_func.x_fhi_aims_controlInOut_basis_func_l = val[i][1]
-                elif 'basis function' in key:
-                    for i in range(len(val)):
-                        sec_basis_func = sec_atom_species.m_create(
-                            x_fhi_aims_section_controlInOut_basis_func)
-                        sec_basis_func.x_fhi_aims_controlInOut_basis_func_type = key.split(
-                            'basis')[0].strip()
-                        if val[i][0] == 'L':
-                            sec_basis_func.x_fhi_aims_controlInOut_basis_func_gauss_l = val[i][2]
-                            sec_basis_func.x_fhi_aims_controlInOut_basis_func_gauss_N = val[i][3]
-                            alpha = [val[i][j + 2] for j in range(len(val[i])) if val[i][j] == 'alpha']
-                            weight = [val[i][j + 2] for j in range(len(val[i])) if val[i][j] == 'weight']
-                            alpha = np.array(alpha) * (1 / ureg.angstrom ** 2)
-                            sec_basis_func.x_fhi_aims_controlInOut_basis_func_gauss_alpha = alpha
-                            sec_basis_func.x_fhi_aims_controlInOut_basis_func_gauss_weight = weight
-                        elif len(val[i]) == 2:
-                            sec_basis_func.x_fhi_aims_controlInOut_basis_func_gauss_l = val[i][0]
-                            alpha = np.array(val[i][1]) / ureg.angstrom ** 2
-                            sec_basis_func.x_fhi_aims_controlInOut_basis_func_primitive_gauss_alpha = alpha
+                # From legacy versions we know that 'free-atom' or 'free-ion' are connected to 'occ'
+                # and 'hydrogenic' to 'eff_charge'. Nothing for 'ionic'
 
         # add inout parameters read from main output
         if (species := self.out_parser.get('control_inout', {}).get('species')) is not None:

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -78,7 +78,7 @@ class FHIAimsControlParser(TextParser):
         def str_to_species(val_in):
             lines = []
             line = ''
-            val_in = val_in.strip().splitlines()
+            val_in = val_in.strip().splitlines()[:-1]
             val_in.reverse()
             for v in val_in:
                 line = v.strip().split('#')[0].replace('.d', '.e') + ' '+ line
@@ -154,7 +154,7 @@ class FHIAimsControlParser(TextParser):
                 'xc', rf'{re_n} *xc\s*([\w\. \-\+]+)', repeats=False),
             Quantity(
                 'species', rf'{re_n} *(species\s+[A-Z][a-z]?[\s\S]+?)'
-                r'FHI-aims code project|\-{10}',
+                r'(FHI-aims code project|\-{10})',
                 str_operation=str_to_species, repeats=True,),
         ]
 
@@ -1556,11 +1556,12 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
                             gauss_alphas, gauss_coeffs = [], []
                             for gaussian_index, gaussian_extra in enumerate(v[2:]):
                                 if gaussian_index % 2:
-                                    gauss_alphas.append(float(gaussian_extra))
-                                else:
                                     gauss_coeffs.append(float(gaussian_extra))
+                                else:
+                                    gauss_alphas.append(float(gaussian_extra))
                             sec_basis_func.x_fhi_aims_controlIn_basis_func_gauss_alphas = np.array(gauss_alphas) / ureg.bohr ** 2
-                            sec_basis_func.x_fhi_aims_controlIn_basis_func_gauss_coeffs = gauss_coeffs
+                            if gauss_coeffs:
+                                sec_basis_func.x_fhi_aims_controlIn_basis_func_gauss_coeffs = gauss_coeffs
                         else:
                             sec_basis_func.x_fhi_aims_controlIn_basis_func_n = int(v[0])
                             sec_basis_func.x_fhi_aims_controlIn_basis_func_l = str(v[1])

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -78,15 +78,12 @@ class FHIAimsControlParser(TextParser):
     def init_quantities(self):
         def str_to_species(val_in):
             val = val_in.strip().splitlines()
-            data = []
             species = dict()
             for v in val:
                 v = v.strip().split('#')[0]
                 if not v or not v[0].isalpha():
                     continue
                 if v.startswith('species'):
-                    if species:
-                        data.append(species)
                     species = dict(species=v.split()[1:])
                 else:
                     v = v.replace('.d', '.e').split()
@@ -95,8 +92,7 @@ class FHIAimsControlParser(TextParser):
                         species[v[0]].extend([vi])
                     else:
                         species[v[0]] = [vi]
-            data.append(species)
-            return data
+            return species
 
         self._quantities = [
             Quantity(
@@ -154,9 +150,9 @@ class FHIAimsControlParser(TextParser):
                 'xc',
                 rf'{re_n} *xc\s*([\w\. \-\+]+)', repeats=False),
             Quantity(
-                'species', rf'{re_n} *(species\s*[A-Z][a-z]?[\s\S]+?)'
-                r'(?:species\s*[A-Z][a-z]?|Completed|\-{10})',
-                str_operation=str_to_species, repeats=False)]
+                'species', rf'{re_n} *(species\s+[A-Z][a-z]?[\s\S]+?)'
+                r'(FHI-aims code project|\-{10})',
+                str_operation=str_to_species, repeats=True)]
 
 
 class FHIAimsOutParser(TextParser):

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -1816,9 +1816,7 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
                             sec_basis_func.x_fhi_aims_controlInOut_basis_func_primitive_gauss_alpha = alpha
 
         # add inout parameters read from main output
-        # species
-        species = self.out_parser.get('control_inout', {}).get('species')
-        if species is not None:
+        if (species := self.out_parser.get('control_inout', {}).get('species')) is not None:
             for specie in species:
                 parse_atom_type(specie)
 

--- a/electronicparsers/utils/__init__.py
+++ b/electronicparsers/utils/__init__.py
@@ -17,5 +17,5 @@
 # limitations under the License.
 
 from .utils import (
-    extract_section, get_files, BeyondDFTWorkflowsParser
+    extract_section, get_files, BeyondDFTWorkflowsParser, get_basis_hash
 )

--- a/electronicparsers/utils/__init__.py
+++ b/electronicparsers/utils/__init__.py
@@ -17,5 +17,5 @@
 # limitations under the License.
 
 from .utils import (
-    extract_section, get_files, BeyondDFTWorkflowsParser, get_basis_hash
+    extract_section, get_files, BeyondDFTWorkflowsParser, hash_section
 )

--- a/electronicparsers/utils/utils.py
+++ b/electronicparsers/utils/utils.py
@@ -90,8 +90,8 @@ def get_files(pattern: str, filepath: str, stripname: str = '', deep: bool = Tru
 
 
 def hash_section(
-        sections: Union(MSection, list[MSection]),
-        subsections: Union(bool, list[bool]),
+        sections: Union[MSection, list[MSection]],
+        subsections: Union[bool, list[bool]],
         **kwargs,
     ) -> str:
     '''
@@ -100,16 +100,16 @@ def hash_section(
     The option consists of adding also general settings to the hash.
 
     There are two modes determining whether sections are defined by the `quantities` provided (`inclusion`)
-    or rather `quantities` are explicitely removed (`exclusion`).
+    or rather `quantities` are explicitly removed (`exclusion`).
 
     `sections`: sections to be hashed together
-    `subsections`: list of bools, indicating whether to include susbections. Must be of same length as basis_settings.
-    `mode`: str, either `inclusion` or `exclusion`
+    `subsections`: list of bools, indicating whether to include subsections. Must be of same length as basis_settings.
+    `mode`: str, either `include` or `exclude` (default)
     `quantities`: list of str, quantities to be included or excluded
     '''
     sections = [sections] if isinstance(sections, MSection) else sections
     subsections = [subsections] if isinstance(subsections, bool) else subsections
-    mode: str = kwargs.get('mode', 'exclusion')
+    mode: str = kwargs.get('mode', 'exclude')
     quantities: list[str] = kwargs.get('quantities', [])
     # sanity checks
     try:
@@ -129,8 +129,8 @@ def hash_section(
                 isinstance(getattr(section, key), (MSection, MSubSectionList)):
                     continue
             if key == 'm_def' or\
-                (mode == 'exclusion' and key not in quantities) or\
-                (mode == 'inclusion' and key in quantities):
+                (mode == 'exclude' and key not in quantities) or\
+                (mode == 'include' and key in quantities):
                     to_write[key] = val
         to_compare.append(to_write)
     # hash the filtered sections


### PR DESCRIPTION
This is an intermediate implementation. It removes `controlInOut` for `controlIn`, which has been patched.
It also introduces general functions for producing tier hashes.

The latter still have to be applied, but this requires an update of the tier references.
Atm, this was done in an external project, but I can make it run locally. I just need to merge [this](https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/1233) first.

Maybe we can already merge this and add the rest later? Depends on how much time I get to work on this.

Closes #131 and https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/issues/1576