### PR TITLE
170 broken parsing of 0d systems in crystal

### DIFF
--- a/electronicparsers/crystal/parser.py
+++ b/electronicparsers/crystal/parser.py
@@ -615,7 +615,6 @@ class CrystalParser:
         # System. There are several alternative sources for this information
         # depending on the run type.
         system = run.m_create(System)
-        material_type = out["material_type"]
         system_edited = out["system_edited"]
         labels_positions = out["labels_positions"]
         lattice_vectors_restart = out["lattice_vectors_restart"]

--- a/electronicparsers/crystal/parser.py
+++ b/electronicparsers/crystal/parser.py
@@ -999,7 +999,7 @@ def to_k_points(segments):
     return all_k_points
 
 
-def to_system(atomic_numbers, labels, positions, lattice, dimensionality, wrap=False):
+def to_system(atomic_numbers, labels, positions, lattice, dimensionality):
     """Converts a Crystal-specific structure format into cartesian positions
     and lattice vectors (if present). The conversion depends on the material
     type.
@@ -1019,33 +1019,21 @@ def to_system(atomic_numbers, labels, positions, lattice, dimensionality, wrap=F
 
     # Convert positions based on the given type
     if dimensionality == 0:
-        if lattice_vectors is not None and wrap:
-            cart_pos = atomutils.wrap_positions(positions, lattice_vectors)
-        else:
-            cart_pos = positions
+        cart_pos = positions
     elif dimensionality == 2:
         n_atoms = atomic_numbers.shape[0]
         scaled_pos = np.zeros((n_atoms, 3), dtype=np.float64)
         scaled_pos[:, 0:2] = positions[:, 0:2]
-        if wrap:
-            wrapped_pos = atomutils.wrap_positions(scaled_pos)
-        else:
-            wrapped_pos = scaled_pos
-        cart_pos = atomutils.to_cartesian(wrapped_pos, lattice_vectors)
+        cart_pos = atomutils.to_cartesian(scaled_pos, lattice_vectors)
         cart_pos[:, 2:3] = positions[:, 2:3]
     elif dimensionality == 1:
         n_atoms = atomic_numbers.shape[0]
         scaled_pos = np.zeros((n_atoms, 3), dtype=np.float64)
         scaled_pos[:, 0:1] = positions[:, 0:1]
-        if wrap:
-            wrapped_pos = atomutils.wrap_positions(scaled_pos)
-        else:
-            wrapped_pos = scaled_pos
-        cart_pos = atomutils.to_cartesian(wrapped_pos, lattice_vectors)
+        cart_pos = atomutils.to_cartesian(scaled_pos, lattice_vectors)
         cart_pos[:, 1:3] = positions[:, 1:3]
     elif dimensionality == 3:
-        scaled_pos = atomutils.wrap_positions(positions) if wrap else positions
-        cart_pos = atomutils.to_cartesian(scaled_pos, lattice_vectors)
+        cart_pos = atomutils.to_cartesian(positions, lattice_vectors)
 
     if lattice_vectors is not None:
         lattice_vectors *= ureg.angstrom

--- a/electronicparsers/crystal/parser.py
+++ b/electronicparsers/crystal/parser.py
@@ -620,7 +620,10 @@ class CrystalParser:
         labels_positions = out["labels_positions"]
         lattice_vectors_restart = out["lattice_vectors_restart"]
         dimensionality = out["dimensionality"]
-        pbc = np.array([True] * dimensionality + [False] * (3 - dimensionality))
+        if dimensionality == 0:
+            pbc = np.array([False] * 3)
+        else:
+            pbc = np.array([True] * 3)
 
         # By default the system is read from the configuration at the beginning
         # of the file: it may come from restart or clean start

--- a/electronicparsers/crystal/parser.py
+++ b/electronicparsers/crystal/parser.py
@@ -168,25 +168,19 @@ class CrystalParser:
                     dtype=str,
                     repeats=False,
                 ),
+                Quantity(
+                    "labels_positions_raw",
+                    fr'AT\.IRR\.\s+AT\s+AT\.N\.\s+X\s+Y\s+Z\s*{br}' +\
+                    fr'((?:\s+{integer}\s+{integer}\s+{integer}\s+{flt}\s+{flt}\s+{flt}{br})+)',
+                    shape=(-1, 6),
+                    dtype=str,
+                ),
 
                 # Used to capture an edited geometry. Can contain
                 # substitutions, supercells, deformations etc. in any order.
                 Quantity(
                     'system_edited',
                     fr' \*\s+GEOMETRY EDITING([\s\S]+?)T = ATOM BELONGING TO THE ASYMMETRIC UNIT',
-                    # too many [\s\S] causing problems
-                    # re.escape(' *******************************************************************************') + fr'{br}' +\
-                    # fr' LATTICE PARAMETERS \(ANGSTROMS AND DEGREES\) - BOHR =\s*0?\.\d+ ANGSTROM{br}' +\
-                    # fr' (?:PRIMITIVE CELL - CENTRING CODE [\s\S]+?VOLUME=\s*{flt} - DENSITY\s*{flt} g/cm\^3|PRIMITIVE CELL){br}' +\
-                    # fr'\s+A\s+B\s+C\s+ALPHA\s+BETA\s+GAMMA\s*{br}' +\
-                    # fr'(\s+{flt}\s+{flt}\s+{flt}\s+{flt}\s+{flt}\s+{flt}{br}' +\
-                    # re.escape(' *******************************************************************************') + fr'{br}' +\
-                    # fr' ATOMS IN THE ASYMMETRIC UNIT\s+{integer} - ATOMS IN THE UNIT CELL:\s+{integer}{br}' +\
-                    # fr'\s+ATOM\s+X(?:/A|\(ANGSTROM\))\s+Y(?:/B|\(ANGSTROM\))\s+Z(?:/C|\(ANGSTROM\))(?:\s+R\(ANGS\))?\s*{br}' +\
-                    # re.escape(' *******************************************************************************') +\
-                    # fr'(?:\s+{integer}\s+(?:T|F)\s+{integer}\s+[\s\S]+?\s+{flt}\s+{flt}\s+{flt}(?:\s+{flt})?{br})+)' +\
-                    # fr'{br}' +\
-                    # fr' T = ATOM BELONGING TO THE ASYMMETRIC UNIT',
                     sub_parser=TextParser(quantities=[
                         Quantity(
                             "lattice_parameters",
@@ -195,13 +189,6 @@ class CrystalParser:
                             shape=(6),
                             dtype=np.float64,
                             repeats=False,
-                        ),
-                        Quantity(
-                            "lattice_positions_raw",
-                            fr'AT\.IRR\.\s+AT\s+AT\.N\.\s+X\s+Y\s+Z\s*{br}' +\
-                            fr'((?:\s+{integer}\s+{integer}\s+{integer}\s+{flt}\s+{flt}\s+{flt}{br})+)',
-                            shape=(-1, 6),
-                            dtype=str,
                         ),
                         Quantity(
                             "labels_positions",
@@ -1009,9 +996,9 @@ def to_k_points(segments):
 
 
 def to_system(atomic_numbers, labels, positions, lattice, dimensionality):
-    """Converts a Crystal-specific structure format into cartesian positions
-    and lattice vectors (if present). The conversion depends on the material
-    type.
+    """Converts a Crystal structure format, i.e. scaled for axes with PBC
+    and Cartesian for the rest, to fully Cartesian positions and lattice vectors, if present.
+    The conversion depends on the dimensionality.
     """
     atomic_numbers = std_atomic_number(atomic_numbers.astype(np.int32))
     atom_labels = std_label(labels)

--- a/electronicparsers/crystal/parser.py
+++ b/electronicparsers/crystal/parser.py
@@ -999,7 +999,7 @@ def to_k_points(segments):
     return all_k_points
 
 
-def to_system(atomic_numbers, labels, positions, lattice, pos_type, wrap=False):
+def to_system(atomic_numbers, labels, positions, lattice, dimensionality, wrap=False):
     """Converts a Crystal-specific structure format into cartesian positions
     and lattice vectors (if present). The conversion depends on the material
     type.
@@ -1018,12 +1018,12 @@ def to_system(atomic_numbers, labels, positions, lattice, pos_type, wrap=False):
         lattice_vectors = None
 
     # Convert positions based on the given type
-    if pos_type == 0:
+    if dimensionality == 0:
         if lattice_vectors is not None and wrap:
             cart_pos = atomutils.wrap_positions(positions, lattice_vectors)
         else:
             cart_pos = positions
-    elif pos_type == 2:
+    elif dimensionality == 2:
         n_atoms = atomic_numbers.shape[0]
         scaled_pos = np.zeros((n_atoms, 3), dtype=np.float64)
         scaled_pos[:, 0:2] = positions[:, 0:2]
@@ -1033,7 +1033,7 @@ def to_system(atomic_numbers, labels, positions, lattice, pos_type, wrap=False):
             wrapped_pos = scaled_pos
         cart_pos = atomutils.to_cartesian(wrapped_pos, lattice_vectors)
         cart_pos[:, 2:3] = positions[:, 2:3]
-    elif pos_type == 1:
+    elif dimensionality == 1:
         n_atoms = atomic_numbers.shape[0]
         scaled_pos = np.zeros((n_atoms, 3), dtype=np.float64)
         scaled_pos[:, 0:1] = positions[:, 0:1]
@@ -1043,7 +1043,7 @@ def to_system(atomic_numbers, labels, positions, lattice, pos_type, wrap=False):
             wrapped_pos = scaled_pos
         cart_pos = atomutils.to_cartesian(wrapped_pos, lattice_vectors)
         cart_pos[:, 1:3] = positions[:, 1:3]
-    elif pos_type == 3:
+    elif dimensionality == 3:
         scaled_pos = atomutils.wrap_positions(positions) if wrap else positions
         cart_pos = atomutils.to_cartesian(scaled_pos, lattice_vectors)
 

--- a/electronicparsers/crystal/parser.py
+++ b/electronicparsers/crystal/parser.py
@@ -620,9 +620,9 @@ class CrystalParser:
         lattice_vectors_restart = out["lattice_vectors_restart"]
         dimensionality = out["dimensionality"]
         if dimensionality == 0:
-            pbc = np.array([False] * 3)
+            pbc = np.zeros(3, dtype=bool)
         else:
-            pbc = np.array([True] * 3)
+            pbc = np.ones(3, dtype=bool)
 
         # By default the system is read from the configuration at the beginning
         # of the file: it may come from restart or clean start

--- a/tests/test_crystalparser.py
+++ b/tests/test_crystalparser.py
@@ -267,7 +267,10 @@ def asserts_basic(archive, method_type="DFT", system_type="3D", vdw=None, forces
         if system_type != "0D":
             assert system.atoms.lattice_vectors is not None
             assert system.atoms.lattice_vectors.shape == (3, 3)
-            assert system.atoms.periodic == [True, True, True]
+            assert system.atoms.periodic == [True] * 3
+        else:
+            assert system.atoms.lattice_vectors is None
+            assert system.atoms.periodic == [False] * 3
         assert system.atoms.positions.shape[0] == n_atoms
         assert system.atoms.species.shape[0] == n_atoms
         assert len(system.atoms.labels) == n_atoms


### PR DESCRIPTION
I fixed the lattice parameter assignment causing the bug in issue #170.
It now uses the `dimensionality` to assign `cart_pos`, rather than the system type.
I also cleaned up `to_system`, which assigned the Cartesian positions.

I slightly extended the tests, but I can see to also include an actual sample of the original bug report.
All examples from the bug report now pass, see figure.

![Screenshot from 2023-11-02 23-36-52](https://github.com/nomad-coe/electronic-parsers/assets/107392603/289baa48-95ae-4638-ac42-515a55768221)
