### PR TITLE
Fix magres and add atom labels

### DIFF
--- a/electronicparsers/magres/metainfo/magres.py
+++ b/electronicparsers/magres/metainfo/magres.py
@@ -30,5 +30,75 @@ from nomad.metainfo import (  # pylint: disable=unused-import
     Reference,
 )
 
+from runschema.calculation import (
+    MagneticShielding as BaseMagneticShielding,
+    ElectricFieldGradient as BaseElectricFieldGradient,
+    SpinSpinCoupling as BaseSpinSpinCoupling,
+)
+
 
 m_package = Package()
+
+
+class MagneticShielding(BaseMagneticShielding):
+    """
+    Section extensions for the Run.Calculation.MagneticShielding base section.
+    """
+
+    m_def = Section(validate=False, extends_base_section=True)
+
+    atoms = Quantity(
+        type=np.str_,
+        shape=['n_atoms', 2],
+        description="""
+        Identifier for the atoms involved in the magnetic shielding tensor. This a list of
+        `n_atoms` pairs of strings [atom_label, atom_index]. The atom index corresponds to the position
+        on the list `System.atoms.labels`.
+        """,
+    )
+
+
+class ElectricFieldGradient(BaseElectricFieldGradient):
+    """
+    Section extensions for the Run.Calculation.ElectricFieldGradient base section.
+    """
+
+    m_def = Section(validate=False, extends_base_section=True)
+
+    atoms = Quantity(
+        type=np.str_,
+        shape=['n_atoms', 2],
+        description="""
+        Identifier for the atoms involved in the electric field gradient tensor. This a list of
+        `n_atoms` pairs of strings [atom_label, atom_index]. The atom index corresponds to the position
+        on the list `System.atoms.labels`.
+        """,
+    )
+
+
+class SpinSpinCoupling(BaseSpinSpinCoupling):
+    """
+    Section extensions for the Run.Calculation.SpinspinCoupling base section.
+    """
+
+    m_def = Section(validate=False, extends_base_section=True)
+
+    atoms_1 = Quantity(
+        type=np.str_,
+        shape=['n_atoms', 2],
+        description="""
+        Identifier for the atoms involved in the spin-spin coupling J12 for the 1 atoms. This a list of
+        `n_atoms` pairs of strings [atom_label, atom_index]. The atom index corresponds to the position
+        on the list `System.atoms.labels`.
+        """,
+    )
+
+    atoms_2 = Quantity(
+        type=np.str_,
+        shape=['n_atoms', 2],
+        description="""
+        Identifier for the atoms involved in the spin-spin coupling J12 for the 2 atoms. This a list of
+        `n_atoms` pairs of strings [atom_label, atom_index]. The atom index corresponds to the position
+        on the list `System.atoms.labels`.
+        """,
+    )

--- a/electronicparsers/magres/metainfo/magres.py
+++ b/electronicparsers/magres/metainfo/magres.py
@@ -47,7 +47,7 @@ class MagneticShielding(BaseMagneticShielding):
 
     # ! These quantities should be implemented in `BaseMagneticShielding` as refs to the specific `AtomsState`
 
-    m_def = Section(validate=False, extends_base_section=True)
+    m_def = Section(extends_base_section=True)
 
     atoms = Quantity(
         type=np.str_,
@@ -67,7 +67,7 @@ class ElectricFieldGradient(BaseElectricFieldGradient):
 
     # ! These quantities should be implemented in `BaseElectricFieldGradient` as refs to the specific `AtomsState`
 
-    m_def = Section(validate=False, extends_base_section=True)
+    m_def = Section(extends_base_section=True)
 
     atoms = Quantity(
         type=np.str_,
@@ -87,7 +87,7 @@ class SpinSpinCoupling(BaseSpinSpinCoupling):
 
     # ! These quantities should be implemented in `BaseSpinSpinCoupling` as refs to the specific `AtomsState`g`
 
-    m_def = Section(validate=False, extends_base_section=True)
+    m_def = Section(extends_base_section=True)
 
     atoms_1 = Quantity(
         type=np.str_,

--- a/electronicparsers/magres/metainfo/magres.py
+++ b/electronicparsers/magres/metainfo/magres.py
@@ -45,6 +45,8 @@ class MagneticShielding(BaseMagneticShielding):
     Section extensions for the Run.Calculation.MagneticShielding base section.
     """
 
+    # ! These quantities should be implemented in `BaseMagneticShielding` as refs to the specific `AtomsState`
+
     m_def = Section(validate=False, extends_base_section=True)
 
     atoms = Quantity(
@@ -63,6 +65,8 @@ class ElectricFieldGradient(BaseElectricFieldGradient):
     Section extensions for the Run.Calculation.ElectricFieldGradient base section.
     """
 
+    # ! These quantities should be implemented in `BaseElectricFieldGradient` as refs to the specific `AtomsState`
+
     m_def = Section(validate=False, extends_base_section=True)
 
     atoms = Quantity(
@@ -80,6 +84,8 @@ class SpinSpinCoupling(BaseSpinSpinCoupling):
     """
     Section extensions for the Run.Calculation.SpinspinCoupling base section.
     """
+
+    # ! These quantities should be implemented in `BaseSpinSpinCoupling` as refs to the specific `AtomsState`g`
 
     m_def = Section(validate=False, extends_base_section=True)
 

--- a/electronicparsers/magres/parser.py
+++ b/electronicparsers/magres/parser.py
@@ -36,12 +36,11 @@ from runschema.system import System, Atoms
 from runschema.calculation import (
     Calculation,
     MagneticSusceptibility,
-)
-from .metainfo.magres import (  # we patch magres metainfo outputs to add atom_labels
     MagneticShielding,
     ElectricFieldGradient,
     SpinSpinCoupling,
 )
+from .metainfo.magres import m_package
 
 # For the automatic workflow NMR
 from nomad.search import search

--- a/tests/test_magresparser.py
+++ b/tests/test_magresparser.py
@@ -69,7 +69,7 @@ def test_single_point_ethanol(parser):
     assert sec_ms.atoms.shape == (9, 2)
     assert (sec_ms.atoms[3] == ['H', '4']).all()
     assert sec_ms.value.shape == (9, 3, 3)
-    assert sec_ms.value[4][2][1] == approx(-7.045255458410382e-06)
+    assert sec_ms.value[4][2][1] == approx(-8.661757088509511e-06)
     assert sec_ms.isotropic_value.shape == (9,)
     assert sec_ms.isotropic_value[4] == approx(3.035708828276491e-05)
     # Electric field gradient testing

--- a/tests/test_magresparser.py
+++ b/tests/test_magresparser.py
@@ -66,6 +66,8 @@ def test_single_point_ethanol(parser):
     # Magnetic shielding testing
     assert len(sec_calc.magnetic_shielding) == 1
     sec_ms = sec_calc.magnetic_shielding[-1]
+    assert sec_ms.atoms.shape == (9, 2)
+    assert (sec_ms.atoms[3] == ['H', '4']).all()
     assert sec_ms.value.shape == (9, 3, 3)
     assert sec_ms.value[4][2][1] == approx(-7.045255458410382e-06)
     assert sec_ms.isotropic_value.shape == (9,)


### PR DESCRIPTION
@ladinesa would you mind taking a look while I fix the test_magres.py?

I am still having issues in the front end, like I said privately. I tried setting up and generating the GUI artifacts, but it is not working. This is some example, and you can check under `run.calculation.magnetic_shielding` that there is no `value` or `isotropic_value`:

[coesite.zip](https://github.com/nomad-coe/electronic-parsers/files/14773378/coesite.zip)