### PR TITLE
use np.float64 instead of np.float

### DIFF
--- a/electronicparsers/ams/parser.py
+++ b/electronicparsers/ams/parser.py
@@ -809,7 +809,7 @@ class OutParser(TextParser):
                             Quantity(
                                 'total',
                                 rf'Total\s+({re_float})',
-                                dtype=np.float,
+                                dtype=np.float64,
                                 unit=ureg.elementary_charge,
                             ),
                         ]


### PR DESCRIPTION
`np.float` got [deprecated](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) in numpy 1.20 