### PR TITLE
ruff fixes

### DIFF
--- a/electronicparsers/ams/rkf.py
+++ b/electronicparsers/ams/rkf.py
@@ -501,7 +501,7 @@ class KFFile:
         valtype = type(val[0])
         t, step, f = KFFile._types[valtype]
         nl = len(val)
-        if valtype == str and isinstance(val, list):
+        if valtype is str and isinstance(val, list):
             # udmpkf reads 160 characters per variable, split over max. 80 per line, to make a string array
             nl = nl * 160
             step = 1

--- a/electronicparsers/crystal/parser.py
+++ b/electronicparsers/crystal/parser.py
@@ -1676,12 +1676,12 @@ def to_libxc(exchange, correlation, exchange_correlation):
     return functionals
 
 
-def to_libxc_out(xc, hybridization):
+def to_libxc_out(xc_output, hybridization):
     """Transforms the Crystal-specific XC naming in the output into a list of
     section_XC_functionals.
     """
     xc_list = []
-    exchange, correlation = xc[1:-1].split(')[')
+    exchange, correlation = xc_output[1:-1].split(')[')
 
     # Handle the exchange part
     if exchange:

--- a/electronicparsers/psi4/parser.py
+++ b/electronicparsers/psi4/parser.py
@@ -1101,7 +1101,7 @@ class Psi4Parser:
                 calc.multipoles.append(multipoles) if len(
                     calc.multipoles
                 ) <= n else calc.multipoles[n]
-                multipoles.kind = multipole_kinds[n]
+                multipoles.kind = multipole
                 parse_multipole(data, multipoles)
 
             multipole_moments = source.get('multipole_moments', {})

--- a/electronicparsers/turbomole/parser.py
+++ b/electronicparsers/turbomole/parser.py
@@ -236,7 +236,7 @@ class OutParser(TextParser):
                 values_str = re.findall(pattern, val_in)
                 values = []
                 for value in values_str:
-                    if dtype == float:
+                    if dtype is float:
                         values.extend(re_value.findall(value))
                     else:
                         values.extend(value.split())

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -1223,9 +1223,9 @@ class RunContentParser(ContentParser):
                 name = name if name else base_name
                 dtype = self._dtypes.get(dtype, str)
                 value = value.split()
-                if dtype == bool:
+                if dtype is bool:
                     value = [v == 'T' for v in value]
-                if dtype == float:
+                if dtype is float:
                     # prevent nan printouts
                     value = parse_float_str_vector(value)
                 # using numpy array does not work

--- a/electronicparsers/yambo/parser.py
+++ b/electronicparsers/yambo/parser.py
@@ -501,8 +501,10 @@ class NetCDFParser(FileParser):
             return
 
         self._keys = list(self.netcdf_file.variables.keys())
-        for key in self._keys:
-            self._results[key] = self.netcdf_file.variables[key][:].data
+        for netcdf_variable in self._keys:
+            self._results[netcdf_variable] = self.netcdf_file.variables[
+                netcdf_variable
+            ][:].data
 
 
 class InputParser(TextParser):


### PR DESCRIPTION
```
electronicparsers/ams/rkf.py:504:12: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
502 |         t, step, f = KFFile._types[valtype]
503 |         nl = len(val)
504 |         if valtype == str and isinstance(val, list):
    |            ^^^^^^^^^^^^^^ E721
505 |             # udmpkf reads 160 characters per variable, split over max. 80 per line, to make a string array
506 |             nl = nl * 160
    |

electronicparsers/crystal/parser.py:1724:9: PLR1704 Redefining argument with the local name `xc`
     |
1722 |         section.weight = float(hybridization) / 100
1723 |         functionals.append(section)
1724 |     for xc in xc_list:
     |         ^^ PLR1704
1725 |         section = Functional()
1726 |         weight = 1.0
     |

electronicparsers/psi4/parser.py:1104:35: PLR1736 [*] List index lookup in `enumerate()` loop
     |
1102 |                     calc.multipoles
1103 |                 ) <= n else calc.multipoles[n]
1104 |                 multipoles.kind = multipole_kinds[n]
     |                                   ^^^^^^^^^^^^^^^^^^ PLR1736
1105 |                 parse_multipole(data, multipoles)
     |
     = help: Use the loop variable directly

electronicparsers/turbomole/parser.py:239:24: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
237 |                 values = []
238 |                 for value in values_str:
239 |                     if dtype == float:
    |                        ^^^^^^^^^^^^^^ E721
240 |                         values.extend(re_value.findall(value))
241 |                     else:
    |

electronicparsers/vasp/parser.py:1226:20: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
     |
1224 |                 dtype = self._dtypes.get(dtype, str)
1225 |                 value = value.split()
1226 |                 if dtype == bool:
     |                    ^^^^^^^^^^^^^ E721
1227 |                     value = [v == 'T' for v in value]
1228 |                 if dtype == float:
     |

electronicparsers/vasp/parser.py:1228:20: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
     |
1226 |                 if dtype == bool:
1227 |                     value = [v == 'T' for v in value]
1228 |                 if dtype == float:
     |                    ^^^^^^^^^^^^^^ E721
1229 |                     # prevent nan printouts
1230 |                     value = parse_float_str_vector(value)
     |

electronicparsers/yambo/parser.py:504:13: PLR1704 Redefining argument with the local name `key`
    |
503 |         self._keys = list(self.netcdf_file.variables.keys())
504 |         for key in self._keys:
    |             ^^^ PLR1704
505 |             self._results[key] = self.netcdf_file.variables[key][:].data
    |
```