### PR TITLE
Random parser improvements

### DIFF
--- a/electronicparsers/fhiaims/metainfo/fhi_aims.py
+++ b/electronicparsers/fhiaims/metainfo/fhi_aims.py
@@ -1127,15 +1127,6 @@ class Method(runschema.method.Method):
         categories=[x_fhi_aims_controlIn_method],
     )
 
-    x_fhi_aims_controlIn_sc_accuracy_etot = Quantity(
-        type=np.float64,
-        shape=[],
-        description="""
-        -
-        """,
-        categories=[x_fhi_aims_controlIn_method],
-    )
-
     x_fhi_aims_controlIn_sc_accuracy_forces = Quantity(
         type=np.float64,
         shape=[],

--- a/electronicparsers/fhiaims/metainfo/fhi_aims.py
+++ b/electronicparsers/fhiaims/metainfo/fhi_aims.py
@@ -1076,24 +1076,6 @@ class Method(runschema.method.Method):
         categories=[x_fhi_aims_controlIn_method],
     )
 
-    x_fhi_aims_controlIn_occupation_type = Quantity(
-        type=str,
-        shape=[],
-        description="""
-        -
-        """,
-        categories=[x_fhi_aims_controlIn_method],
-    )
-
-    x_fhi_aims_controlIn_occupation_width = Quantity(
-        type=np.float64,
-        shape=[],
-        description="""
-        -
-        """,
-        categories=[x_fhi_aims_controlIn_method],
-    )
-
     x_fhi_aims_controlIn_override_relativity = Quantity(
         type=str,
         shape=[],

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -43,6 +43,7 @@ from runschema.method import (
     KMesh,
     FrequencyMesh,
     BasisSetContainer,
+    Scf,
 )
 from runschema.system import System, Atoms
 from runschema.calculation import (
@@ -84,7 +85,7 @@ from .metainfo.fhi_aims import (
 from ..utils import BeyondDFTWorkflowsParser
 
 
-re_float = r'[-+]?\d+\.\d*(?:[Ee][-+]\d+)?'
+re_float = r'[-+]?\d+\.?\d*(?:[Ee][-+]\d+)?'
 re_n = r'[\n\r]'
 
 
@@ -177,9 +178,10 @@ class FHIAimsControlParser(TextParser):
                 repeats=False,
             ),
             Quantity(
-                xsection_method.x_fhi_aims_controlIn_sc_accuracy_etot,
+                'threshold_energy_change',
                 rf'{re_n} *sc_accuracy_etot\s*({re_float})',
                 repeats=False,
+                unit='eV',
             ),
             Quantity(
                 xsection_method.x_fhi_aims_controlIn_sc_accuracy_forces,
@@ -2227,6 +2229,10 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
                 if hybrid_coeff is not None:
                     # is it necessary to check if xc is a hybrid type aside from hybrid_coeff
                     sec_method.x_fhi_aims_controlIn_hybrid_xc_coeff = hybrid_coeff
+            elif key == 'threshold_energy_change':
+                sec_scf = Scf()
+                sec_method.scf = sec_scf
+                sec_scf.threshold_energy_change = val
 
         inout_exclude = [
             'x_fhi_aims_controlInOut_relativistic',

--- a/electronicparsers/fhiaims/parser.py
+++ b/electronicparsers/fhiaims/parser.py
@@ -44,6 +44,7 @@ from runschema.method import (
     FrequencyMesh,
     BasisSetContainer,
     Scf,
+    Smearing,
 )
 from runschema.system import System, Atoms
 from runschema.calculation import (
@@ -2201,10 +2202,24 @@ class FHIAimsParser(BeyondDFTWorkflowsParser):
                         'Error setting controlIn metainfo.', data=dict(key=key)
                     )
             elif key == 'occupation_type':
-                sec_method.x_fhi_aims_controlIn_occupation_type = val[0]
-                sec_method.x_fhi_aims_controlIn_occupation_width = val[1]
-                if len(val) > 2:
-                    sec_method.x_fhi_aims_controlIn_occupation_order = int(val[2])
+                try:
+                    if val is not None and len(val) >= 2:
+                        # integer and cubic smearing don't match well the upstream metainfo definitions
+                        occupation_types_dict = {
+                            'gaussian': 'gaussian',
+                            'methfessel-paxton': 'methfessel-paxton',
+                            'fermi': 'fermi',
+                            'integer': None,
+                            'cubic': None,
+                            'cold': 'marzari-vanderbilt',
+                        }
+                        kind = occupation_types_dict.get(val[0])
+                        width = (float(val[1]) * ureg.eV).to_base_units().magnitude
+                        sec_electronic.smearing = Smearing(kind=kind, width=width)
+                    if len(val) > 2:
+                        sec_method.x_fhi_aims_controlIn_occupation_order = int(val[2])
+                except Exception as e:
+                    logger.warning(f"Failed to parse smearing info from val={val}: {e}")
             elif key == 'relativistic':
                 if isinstance(val, str):
                     val = [val]

--- a/electronicparsers/openmx/parser.py
+++ b/electronicparsers/openmx/parser.py
@@ -54,6 +54,7 @@ from runschema.method import (
     Scf,
     BasisSetContainer,
     CoreHole,
+    KMesh,
 )
 from nomad.parsing.file_parser import TextParser, Quantity
 from simulationworkflowschema import (
@@ -255,6 +256,11 @@ mainfile_parser = TextParser(
         Quantity(
             'scf.ElectronicTemperature',
             r'scf.ElectronicTemperature\s+(\S+)',
+            repeats=False,
+        ),
+        Quantity(
+            'scf.Kgrid',
+            r'scf.Kgrid\s+(\d+\s+\d+\s+\d+)',
             repeats=False,
         ),
         Quantity('scf.dftD', r'scf.dftD\s+([a-z]+)', repeats=False),
@@ -726,8 +732,16 @@ class OpenmxParser:
         else:
             sec_electronic.van_der_waals_method = ''
 
-    def parse_eigenvalues(self):
+    def parse_eigenvalues_and_kmesh(self):
         eigenvalues = BandEnergies()
+
+        sec_k_mesh = KMesh()
+        self.archive.run[-1].method[-1].k_mesh = sec_k_mesh
+
+        k_mesh_grid = mainfile_parser.get('scf.Kgrid')
+        if k_mesh_grid is not None:
+            sec_k_mesh.grid = k_mesh_grid
+
         self.archive.run[-1].calculation[-1].eigenvalues.append(eigenvalues)
         values = mainfile_parser.get('eigenvalues')
         if values is not None:
@@ -735,9 +749,23 @@ class OpenmxParser:
             if kpoints is not None:
                 eigenvalues.kpoints = kpoints
                 eigenvalues.n_kpoints = len(kpoints)
+                # OpenMX uses only inversion symmetry so every k-point except gamma-point has multiplicity of 2
+                kpoints_multiplicities = []
+                for kpoint in kpoints:
+                    if np.allclose(kpoint, [[0.0, 0.0, 0.0]], rtol=0.0):
+                        kpoints_multiplicities.append(1)
+                    else:
+                        kpoints_multiplicities.append(2)
+                sec_k_mesh.points = np.array(kpoints).astype(complex)
+                sec_k_mesh.multiplicities = kpoints_multiplicities
+                eigenvalues.kpoints_multiplicities = kpoints_multiplicities
             else:
+                # if no explicit k-points are written we have gamma-point only
                 eigenvalues.kpoints = [[0, 0, 0]]
                 eigenvalues.n_kpoints = 1
+                eigenvalues.kpoints_multiplicities = [1]
+                sec_k_mesh.points = [[0, 0, 0]]
+                sec_k_mesh.multiplicities = [1]
             values = values.get('eigenvalues')
             if values is not None:
                 if self.spinpolarized:
@@ -915,4 +943,4 @@ class OpenmxParser:
         except (IndexError, AttributeError):
             pass
 
-        self.parse_eigenvalues()
+        self.parse_eigenvalues_and_kmesh()

--- a/electronicparsers/quantumespresso/parser.py
+++ b/electronicparsers/quantumespresso/parser.py
@@ -40,6 +40,7 @@ from runschema.method import (
     BasisSetContainer,
     AtomParameters,
     KMesh,
+    Scf,
 )
 from runschema.system import System, Atoms
 from runschema.calculation import (
@@ -3334,6 +3335,9 @@ class QuantumEspressoParser:
         sec_kmesh.n_points = run.get_header('k_points', {}).get('nk', 1)
         sec_kmesh.points = run.get_header('k_points', {}).get('points', None)
 
+        if (threshold := run.get_header('scf_threshold_energy_change')) is not None:
+            sec_method.scf = Scf(threshold_energy_change = threshold)
+
         g_vector_sticks = run.get_header('g_vector_sticks', {}).get('Sum', None)
         if g_vector_sticks is not None:
             names = [
@@ -3404,7 +3408,6 @@ class QuantumEspressoParser:
 
         # other method variables
         names = [
-            'scf_threshold_energy_change',
             'x_qe_core_charge_realspace',
             'x_qe_exact_exchange_fraction',
             'x_qe_diagonalization_algorithm',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ lint.ignore = [
 	"PLW2901", # redefined-loop-name
 	"PLR1714", # consider-using-in
 	"PLR5501", # else-if-used
+        "PLC0415", # Import should be at top-level (conflicts with lazy imports)
 ]
 lint.fixable = ["ALL"]
 

--- a/tests/test_fhiaimsparser.py
+++ b/tests/test_fhiaimsparser.py
@@ -62,6 +62,8 @@ def test_scf_spinpol(parser):
     assert list(sec_method.k_mesh.grid) == [16] * 3
     assert sec_method.electronic.n_spin_channels == 2
     assert sec_method.electronic.relativity_method == 'scalar_relativistic_atomic_ZORA'
+    assert sec_method.electronic.smearing.kind == 'gaussian'
+    assert sec_method.electronic.smearing.width == approx(1.602176634e-20)
     assert sec_method.dft.xc_functional.correlation[0].name == 'LDA_C_PW'
     assert sec_method.scf.threshold_energy_change.magnitude == approx(1.602176634e-24)
     sec_basis_func = sec_method.x_fhi_aims_section_controlIn_basis_set[
@@ -106,6 +108,8 @@ def test_geomopt(parser):
     assert len(sec_methods) == 1
     assert list(sec_methods[0].k_mesh.grid) == [8] * 3
     assert sec_methods[0].scf.threshold_energy_change.magnitude == approx(1.602176634e-25)
+    assert sec_methods[0].electronic.smearing.kind == 'gaussian'
+    assert sec_methods[0].electronic.smearing.width == approx(1.602176633e-21)
 
     sec_sccs = archive.run[0].calculation
     assert len(sec_sccs) == 6
@@ -221,6 +225,8 @@ def test_dos(parser):
     sec_method = archive.run[0].method[0]
     assert list(sec_method.k_mesh.grid) == [10] * 3
     assert sec_method.scf.threshold_energy_change.magnitude == approx(1.602176634e-25)
+    assert sec_method.electronic.smearing.kind == 'gaussian'
+    assert sec_method.electronic.smearing.width == approx(1.602176633e-21)
 
     sec_scc = archive.run[0].calculation[0]
     sec_dos = sec_scc.dos_electronic

--- a/tests/test_fhiaimsparser.py
+++ b/tests/test_fhiaimsparser.py
@@ -63,6 +63,7 @@ def test_scf_spinpol(parser):
     assert sec_method.electronic.n_spin_channels == 2
     assert sec_method.electronic.relativity_method == 'scalar_relativistic_atomic_ZORA'
     assert sec_method.dft.xc_functional.correlation[0].name == 'LDA_C_PW'
+    assert sec_method.scf.threshold_energy_change.magnitude == approx(1.602176634e-24)
     sec_basis_func = sec_method.x_fhi_aims_section_controlIn_basis_set[
         0
     ].x_fhi_aims_section_controlIn_basis_func
@@ -104,6 +105,7 @@ def test_geomopt(parser):
     sec_methods = archive.run[0].method
     assert len(sec_methods) == 1
     assert list(sec_methods[0].k_mesh.grid) == [8] * 3
+    assert sec_methods[0].scf.threshold_energy_change.magnitude == approx(1.602176634e-25)
 
     sec_sccs = archive.run[0].calculation
     assert len(sec_sccs) == 6
@@ -218,6 +220,7 @@ def test_dos(parser):
 
     sec_method = archive.run[0].method[0]
     assert list(sec_method.k_mesh.grid) == [10] * 3
+    assert sec_method.scf.threshold_energy_change.magnitude == approx(1.602176634e-25)
 
     sec_scc = archive.run[0].calculation[0]
     sec_dos = sec_scc.dos_electronic

--- a/tests/test_openmxparser.py
+++ b/tests/test_openmxparser.py
@@ -183,7 +183,7 @@ def test_AlN(parser):
     )
 
 
-def test_C2N2(parser):
+def test_C2H2(parser):
     """
     Molecular dynamics using the Nose-Hover thermostat for simple N2H2 molecule
     """

--- a/tests/test_openmxparser.py
+++ b/tests/test_openmxparser.py
@@ -79,6 +79,11 @@ def test_HfO2(parser):
     assert method.electronic.smearing.width == approx(K_to_J(300))
     assert method.dft.xc_functional.correlation[0].name == 'GGA_C_PBE'
     assert method.dft.xc_functional.exchange[0].name == 'GGA_X_PBE'
+    assert (method.k_mesh.grid == [10, 10, 10]).all()
+    assert np.allclose(method.k_mesh.points[0], np.array([-0.45000, -0.45000, -0.45000]).astype(complex), rtol=0.0)
+    assert np.allclose(method.k_mesh.points[499], np.array([-0.05000, 0.45000, 0.45000]).astype(complex), rtol=0.0)
+    assert method.k_mesh.multiplicities[0] == approx(2.0)
+    assert method.k_mesh.multiplicities[0] == approx(2.0)
 
     system = run.system[0]
     assert system.atoms.periodic == [True, True, True]
@@ -89,6 +94,9 @@ def test_HfO2(parser):
     assert system.atoms.positions[11][2].magnitude == approx(A_to_m(2.6762159))
     assert len(system.atoms.labels) == 12
     assert system.atoms.labels[9] == 'O'
+
+    scc = run.calculation
+    assert scc[-1].eigenvalues[0].kpoints_multiplicities[0] == approx(2.0)
 
 
 def test_AlN(parser):
@@ -121,6 +129,9 @@ def test_AlN(parser):
     scf = scc[3].scf_iteration
     assert len(scf) == 6
     scf[5].energy.sum_eigenvalues.value.magnitude == approx(-3.4038520917173614e-17)
+    assert len(scc[-1].eigenvalues[0].kpoints_multiplicities) == 74
+    assert scc[-1].eigenvalues[0].kpoints_multiplicities[-1] == approx(1.0)
+    assert scc[-1].eigenvalues[0].kpoints_multiplicities[0] == approx(2.0)
 
     method = run.method[0]
     assert method.electronic.n_spin_channels == 1
@@ -131,6 +142,11 @@ def test_AlN(parser):
     assert method.dft.xc_functional.exchange[0].name == 'GGA_X_PBE'
     assert method.scf.n_max_iteration == 100
     assert method.scf.threshold_energy_change.magnitude == approx(Ha_to_J(1e-7))
+    assert (method.k_mesh.grid == [7, 7, 3]).all()
+    assert np.allclose(method.k_mesh.points[0], np.array([ -0.42857, -0.42857, -0.33333]).astype(complex), rtol=0.0)
+    assert np.allclose(method.k_mesh.points[73], np.array([0.00000, -0.00000, 0.00000]).astype(complex), rtol=0.0)
+    assert np.allclose(method.k_mesh.multiplicities[0], np.array([2, 2, 2]).astype(complex), rtol=0.0)
+    assert method.k_mesh.multiplicities[73] == [1]
 
     workflow = archive.workflow2
     assert workflow.method.method == 'steepest_descent'
@@ -209,6 +225,7 @@ def test_C2H2(parser):
     assert np.shape(scc[0].forces.total.value) == (4, 3)
     assert scc[0].forces.total.value[0][0].magnitude == approx(HaB_to_N(0.10002))
     assert scc[99].forces.total.value[2][2].magnitude == approx(HaB_to_N(-0.00989))
+    assert scc[-1].eigenvalues[0].kpoints_multiplicities == approx(1.0)
 
     assert len(run.system) == 100
 
@@ -218,6 +235,8 @@ def test_C2H2(parser):
     assert method.electronic.smearing.width == approx(K_to_J(500))
     assert method.dft.xc_functional.exchange[0].name == 'LDA_X'
     assert method.dft.xc_functional.correlation[0].name == 'LDA_C_PZ'
+    assert (method.k_mesh.grid == [1, 1, 1]).all()
+    assert method.k_mesh.multiplicities[0] == approx(1.0)
 
     workflow = archive.workflow2
     assert workflow.method.thermodynamic_ensemble == 'NVT'
@@ -284,6 +303,7 @@ def test_CrO2(parser):
     assert method.dft.xc_functional.correlation[0].name == 'LDA_C_PW'
     assert method.scf.n_max_iteration == 40
     assert method.scf.threshold_energy_change.magnitude == approx(Ha_to_J(1e-7))
+    assert (method.k_mesh.grid == [5, 5, 8]).all()
 
     eigenvalues = run.calculation[-1].eigenvalues[0]
     assert eigenvalues.n_kpoints == 100
@@ -316,6 +336,7 @@ def test_graphite(parser):
     assert method.electronic.van_der_waals_method == 'G10'
     assert method.scf.n_max_iteration == 100
     assert method.scf.threshold_energy_change.magnitude == approx(Ha_to_J(1e-8))
+    assert (method.k_mesh.grid == [12, 12, 4]).all()
 
     calculation_first = run.calculation[0]
     stress_tensor_first = calculation_first.stress.total.value

--- a/tests/test_quantumespressoparser.py
+++ b/tests/test_quantumespressoparser.py
@@ -37,6 +37,10 @@ def RyB_to_N(value):
     return (value * ureg.rydberg / ureg.bohr).to_base_units().magnitude
 
 
+def Ry_to_J(value):
+    return (value * ureg.rydberg).to_base_units().magnitude
+
+
 def test_scf(parser):
     archive = EntryArchive()
     parser.parse('tests/data/quantumespresso/HO_scf/benchmark2.out', archive, None)
@@ -73,6 +77,7 @@ def test_scf(parser):
     assert sec_method.dft.xc_functional.exchange[0].name == 'GGA_X_PBE'
     assert sec_method.electronic.n_electrons == 8
     assert sec_method.electronic.n_spin_channels == 1
+    assert sec_method.scf.threshold_energy_change.magnitude == approx(Ry_to_J(1e-6))
     sec_atoms = sec_method.atom_parameters
     assert len(sec_atoms) == 2
     assert sec_atoms[1].label == 'H'
@@ -157,6 +162,7 @@ def test_multirun(parser):
     assert sec_runs[2].calculation[0].scf_iteration[
         11
     ].time_physical.magnitude == approx(1189.6)
+    assert sec_method.scf.threshold_energy_change.magnitude == approx(Ry_to_J(1e-5))
 
 
 def test_md(parser):
@@ -168,6 +174,7 @@ def test_md(parser):
     sec_method = sec_run.method[0]
     assert len(sec_method.k_mesh.points) == 1
     assert sec_method.electronic.n_spin_channels == 1
+    assert sec_method.scf.threshold_energy_change.magnitude == approx(Ry_to_J(1e-8))
     sec_sccs = sec_run.calculation
     assert len(sec_sccs) == 50
     assert archive.run[0].system[6].atoms.positions[1][2].magnitude == approx(
@@ -217,6 +224,7 @@ def test_vcrelax(parser):
     assert sec_method.electronic.smearing.kind == 'tetrahedra'
     assert sec_method.electronic.smearing.width is None
     assert sec_method.electronic.n_spin_channels == 1
+    assert sec_method.scf.threshold_energy_change.magnitude == approx(Ry_to_J(1e-8))
 
 
 def test_noncolmag(parser):
@@ -243,3 +251,4 @@ def test_noncolmag(parser):
         == (0.01 * ureg.rydberg).to_base_units().magnitude
     )
     assert sec_method.electronic.n_spin_channels is None
+    assert sec_method.scf.threshold_energy_change.magnitude == approx(Ry_to_J(1e-8))


### PR DESCRIPTION
Few random parser fixes, related to one Nomad datamining ongoing minithesis, authored by @simonkratochvil and I did some initial review locally. The OpenMX and QE patches should hopefully be fine. Please double check the FHIaims patches, there I'm far from being an expert. Especially the FHIaims src_threshold_energy patch seems to introduce some normalizing issues with basis set !?! 
```
Traceback (most recent call last):
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad-pyenv/bin/nomad", line 8, in
sys.exit(run_cli())
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad/nomad/cli/cli.py", line 76, in run_cli
return cli(obj=POPO()) # pylint: disable=E1120,E1123
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad-pyenv/lib/python3.9/site-packages/click/core.py", line 1157, in call
return self.main(*args, **kwargs)
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad-pyenv/lib/python3.9/site-packages/click/core.py", line 1078, in main
rv = self.invoke(ctx)
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad-pyenv/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad-pyenv/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
return ctx.invoke(self.callback, **ctx.params)
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad-pyenv/lib/python3.9/site-packages/click/core.py", line 783, in invoke
return __callback(*args, **kwargs)
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad/nomad/cli/parse.py", line 87, in _parse
normalize_all(entry_archive)
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad/nomad/client/processing.py", line 111, in normalize_all
normalize(normalizer, entry_archive, logger=logger)
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad/nomad/client/processing.py", line 96, in normalize
normalizer_instance.normalize(logger=logger)
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad/nomad/normalizing/init.py", line 79, in normalize
self.normalizer.normalize(self.archive, logger)
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad/nomad/normalizing/results.py", line 127, in normalize
self.normalize_run(logger=self.logger)
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad/nomad/normalizing/results.py", line 243, in normalize_run
results.method = MethodNormalizer(
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad/nomad/normalizing/method.py", line 296, in method
simulation = DFTMethod(
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad/nomad/normalizing/method.py", line 555, in simulation
self._method.method_id = self.method_id_dft(
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad/nomad/normalizing/method.py", line 751, in method_id_dft
return method_dict.hash()
File "/Users/simonkratochvil/Documents/nomad_parsers/nomad/nomad/utils/init.py", line 538, in hash
hash_str = json.dumps(self, sort_keys=True)
File "/opt/homebrew/Cellar/python@3.9/3.9.19/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/init.py", line 234, in dumps
return cls(
File "/opt/homebrew/Cellar/python@3.9/3.9.19/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 199, in encode
chunks = self.iterencode(o, _one_shot=True)
File "/opt/homebrew/Cellar/python@3.9/3.9.19/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 257, in iterencode
return _iterencode(o, 0)
File "/opt/homebrew/Cellar/python@3.9/3.9.19/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 179, in default
raise TypeError(f'Object of type {o.class.name} '
TypeError: Object of type x_fhi_aims_section_controlIn_basis_set is not JSON serializable
```

The FHIaims test failures should be preexisting. 