### PR TITLE
242 cp2k parser failing at process

### DIFF
--- a/electronicparsers/cp2k/parser.py
+++ b/electronicparsers/cp2k/parser.py
@@ -2009,7 +2009,7 @@ class CP2KParser:
         bs_gauss = BasisSet(
             scope=['kinetic energy', 'electron-core interaction'],
             type='gaussians',
-        )
+        )  # TODO: review partition in new parser
         atoms = (
             self.out_parser.get(self._calculation_type, {})
             .get('atomic_kind_information', {})
@@ -2022,22 +2022,21 @@ class CP2KParser:
                 ac.atom_number = self.get_atomic_number(atom.kind_label)
                 ac.name = basis_set
                 bs_gauss.atom_centered.append(ac)
+
+        basis_sets: list[BasisSet] = []
         if bs_gauss.atom_centered:
-            bs_pw = BasisSet(
-                scope=['Hartree energy', 'electron-electron interaction'],
-                type='plane waves',
-                cutoff=self.settings.get('qs', {}).get('planewave_cutoff', None)
-                * ureg.hartree,
-            )
-            basis_sets = [bs_pw, bs_gauss]
+            basis_sets.append(bs_gauss)
+            pw_scope = ['Hartree energy', 'electron-electron interaction']
         else:
-            bs_pw = BasisSet(
-                scope=['valence'],
-                type='plane waves',
-                cutoff=self.settings.get('qs', {}).get('planewave_cutoff', None)
-                * ureg.hartree,
-            )
-            basis_sets = [bs_pw]
+            pw_scope = ['valence']
+
+        bs_pw = BasisSet(
+            scope=pw_scope,
+            type='plane waves',
+        )
+        if (cutoff := self.settings.get('qs', {}).get('planewave_cutoff')) is not None:
+            bs_pw.cutoff = cutoff * ureg.hartree
+        basis_sets.append(bs_pw)
         return basis_sets
 
     def parse_method_quickstep(self):

--- a/electronicparsers/cp2k/parser.py
+++ b/electronicparsers/cp2k/parser.py
@@ -1481,9 +1481,17 @@ class CP2KParser:
             sec_run.x_cp2k_section_end_information.append(sec_endinformation)
             section = sec_startinformation
             for key, val in program_settings.items():
-                if key == 'id' and isinstance(val, list):
-                    sec_endinformation.x_cp2k_end_id = val[1]
-                    key, val = 'start_id', val[0]
+                if key == 'id':
+                    if isinstance(val, list):
+                        sec_startinformation.x_cp2k_start_id = val[0]
+                        sec_endinformation.x_cp2k_end_id = val[1]
+                    elif isinstance(val, int):
+                        # logger.warning('Calculation may not have properly terminated: did not encounter end "PROCESS ID".')
+                        sec_startinformation.x_cp2k_start_id = val
+                    else:
+                        # logger.warning('Encountered "PROCESS ID" of unexpected format.')
+                        pass
+                    continue
                 section = (
                     sec_endinformation
                     if key.startswith('end')

--- a/electronicparsers/cp2k/parser.py
+++ b/electronicparsers/cp2k/parser.py
@@ -967,7 +967,7 @@ class CP2KParser:
             'started_at': 'start_time',
             'started_on': 'start_host',
             'started_by': 'start_user',
-            'process_id': 'id',
+            'process_id': 'process_id',
             'started_in': 'start_path',
             'ended_at': 'end_time',
             'ran_on': 'end_host',
@@ -1481,15 +1481,15 @@ class CP2KParser:
             sec_run.x_cp2k_section_end_information.append(sec_endinformation)
             section = sec_startinformation
             for key, val in program_settings.items():
-                if key == 'id':
+                if key == 'process_id':
                     if isinstance(val, list):
                         sec_startinformation.x_cp2k_start_id = val[0]
                         sec_endinformation.x_cp2k_end_id = val[1]
                     elif isinstance(val, int):
-                        # logger.warning('Calculation may not have properly terminated: did not encounter end "PROCESS ID".')
+                        self.logger.warning('Calculation may not have properly terminated: did not encounter end "PROCESS ID".')
                         sec_startinformation.x_cp2k_start_id = val
                     else:
-                        # logger.warning('Encountered "PROCESS ID" of unexpected format.')
+                        self.logger.warning('Encountered "PROCESS ID" of unexpected format.')
                         pass
                     continue
                 section = (

--- a/tests/data/cp2k/single_point/si_bulk8_unterminated.out
+++ b/tests/data/cp2k/single_point/si_bulk8_unterminated.out
@@ -1,0 +1,569 @@
+ DBCSR| Multiplication driver                                                SMM
+ DBCSR| Multrec recursion limit                                              512
+ DBCSR| Multiplication stack size                                           1000
+ DBCSR| Multiplication size stacks                                             3
+ DBCSR| Use subcommunicators                                                   T
+ DBCSR| Use MPI combined types                                                 F
+ DBCSR| Use MPI memory allocation                                              T
+ DBCSR| Use Communication thread                                               T
+ DBCSR| Communication thread load                                             87
+
+
+  **** **** ******  **  PROGRAM STARTED AT               2016-02-08 22:11:01.366
+ ***** ** ***  *** **   PROGRAM STARTED ON                   lauri-Lenovo-Z50-70
+ **    ****   ******    PROGRAM STARTED BY                                 lauri
+ ***** **    ** ** **   PROGRAM PROCESS ID                                  8212
+  **** **  *******  **  PROGRAM STARTED IN /home/lauri/Dropbox/nomad-dev/nomad-l
+                                           ab-base/parsers/cp2k/test/examples/Si
+                                           _bulk8
+
+ CP2K| version string:                                        CP2K version 2.6.2
+ CP2K| source code revision number:                                    svn:15893
+ CP2K| is freely available from                             http://www.cp2k.org/
+ CP2K| Program compiled at                           ke 4.11.2015 08.48.42 +0200
+ CP2K| Program compiled on                                   lauri-Lenovo-Z50-70
+ CP2K| Program compiled for                          Linux-x86-64-gfortran_basic
+ CP2K| Input file name                                              si_bulk8.inp
+
+ GLOBAL| Force Environment number                                              1
+ GLOBAL| Basis set file name                                        ../BASIS_SET
+ GLOBAL| Geminal file name                                         BASIS_GEMINAL
+ GLOBAL| Potential file name                                   ../GTH_POTENTIALS
+ GLOBAL| MM Potential file name                                     MM_POTENTIAL
+ GLOBAL| Coordinate file name                                      __STD_INPUT__
+ GLOBAL| Method name                                                        CP2K
+ GLOBAL| Project name                                                   Si_bulk8
+ GLOBAL| Preferred FFT library                                             FFTW3
+ GLOBAL| Preferred diagonalization lib.                                       SL
+ GLOBAL| Run type                                                   ENERGY_FORCE
+ GLOBAL| All-to-all communication in single precision                          F
+ GLOBAL| FFTs using library dependent lengths                                  F
+ GLOBAL| Global print level                                               MEDIUM
+ GLOBAL| Total number of message passing processes                             1
+ GLOBAL| Number of threads for this process                                    1
+ GLOBAL| This output is from process                                           0
+
+ MEMORY| system memory details [Kb]
+ MEMORY|                        rank 0           min           max       average
+ MEMORY| MemTotal              8070384       8070384       8070384       8070384
+ MEMORY| MemFree               3151936       3151936       3151936       3151936
+ MEMORY| Buffers                842412        842412        842412        842412
+ MEMORY| Cached                2479816       2479816       2479816       2479816
+ MEMORY| Slab                   563496        563496        563496        563496
+ MEMORY| SReclaimable           526832        526832        526832        526832
+ MEMORY| MemLikelyFree         7000996       7000996       7000996       7000996
+
+
+ *** Fundamental physical constants (SI units) ***
+
+ *** Literature: B. J. Mohr and B. N. Taylor,
+ ***             CODATA recommended values of the fundamental physical
+ ***             constants: 2006, Web Version 5.1
+ ***             http://physics.nist.gov/constants
+
+ Speed of light in vacuum [m/s]                             2.99792458000000E+08
+ Magnetic constant or permeability of vacuum [N/A**2]       1.25663706143592E-06
+ Electric constant or permittivity of vacuum [F/m]          8.85418781762039E-12
+ Planck constant (h) [J*s]                                  6.62606896000000E-34
+ Planck constant (h-bar) [J*s]                              1.05457162825177E-34
+ Elementary charge [C]                                      1.60217648700000E-19
+ Electron mass [kg]                                         9.10938215000000E-31
+ Electron g factor [ ]                                     -2.00231930436220E+00
+ Proton mass [kg]                                           1.67262163700000E-27
+ Fine-structure constant                                    7.29735253760000E-03
+ Rydberg constant [1/m]                                     1.09737315685270E+07
+ Avogadro constant [1/mol]                                  6.02214179000000E+23
+ Boltzmann constant [J/K]                                   1.38065040000000E-23
+ Atomic mass unit [kg]                                      1.66053878200000E-27
+ Bohr radius [m]                                            5.29177208590000E-11
+
+ *** Conversion factors ***
+
+ [u] -> [a.u.]                                              1.82288848426455E+03
+ [Angstrom] -> [Bohr] = [a.u.]                              1.88972613288564E+00
+ [a.u.] = [Bohr] -> [Angstrom]                              5.29177208590000E-01
+ [a.u.] -> [s]                                              2.41888432650478E-17
+ [a.u.] -> [fs]                                             2.41888432650478E-02
+ [a.u.] -> [J]                                              4.35974393937059E-18
+ [a.u.] -> [N]                                              8.23872205491840E-08
+ [a.u.] -> [K]                                              3.15774647902944E+05
+ [a.u.] -> [kJ/mol]                                         2.62549961709828E+03
+ [a.u.] -> [kcal/mol]                                       6.27509468713739E+02
+ [a.u.] -> [Pa]                                             2.94210107994716E+13
+ [a.u.] -> [bar]                                            2.94210107994716E+08
+ [a.u.] -> [atm]                                            2.90362800883016E+08
+ [a.u.] -> [eV]                                             2.72113838565563E+01
+ [a.u.] -> [Hz]                                             6.57968392072181E+15
+ [a.u.] -> [1/cm] (wave numbers)                            2.19474631370540E+05
+ [a.u./Bohr**2] -> [1/cm]                                   5.14048714338585E+03
+
+
+ CELL_TOP| Volume [angstrom^3]:                                          160.165
+ CELL_TOP| Vector a [angstrom     5.431     0.000     0.000    |a| =       5.431
+ CELL_TOP| Vector b [angstrom     0.000     5.431     0.000    |b| =       5.431
+ CELL_TOP| Vector c [angstrom     0.000     0.000     5.431    |c| =       5.431
+ CELL_TOP| Angle (b,c), alpha [degree]:                                   90.000
+ CELL_TOP| Angle (a,c), beta  [degree]:                                   90.000
+ CELL_TOP| Angle (a,b), gamma [degree]:                                   90.000
+ CELL_TOP| Numerically orthorhombic:                                         YES
+
+ GENERATE|  Preliminary Number of Bonds generated:                             0
+ GENERATE|  Achieved consistency in connectivity generation.
+
+ CELL| Volume [angstrom^3]:                                              160.165
+ CELL| Vector a [angstrom]:       5.431     0.000     0.000    |a| =       5.431
+ CELL| Vector b [angstrom]:       0.000     5.431     0.000    |b| =       5.431
+ CELL| Vector c [angstrom]:       0.000     0.000     5.431    |c| =       5.431
+ CELL| Angle (b,c), alpha [degree]:                                       90.000
+ CELL| Angle (a,c), beta  [degree]:                                       90.000
+ CELL| Angle (a,b), gamma [degree]:                                       90.000
+ CELL| Numerically orthorhombic:                                             YES
+
+ CELL_REF| Volume [angstrom^3]:                                          160.165
+ CELL_REF| Vector a [angstrom     5.431     0.000     0.000    |a| =       5.431
+ CELL_REF| Vector b [angstrom     0.000     5.431     0.000    |b| =       5.431
+ CELL_REF| Vector c [angstrom     0.000     0.000     5.431    |c| =       5.431
+ CELL_REF| Angle (b,c), alpha [degree]:                                   90.000
+ CELL_REF| Angle (a,c), beta  [degree]:                                   90.000
+ CELL_REF| Angle (a,b), gamma [degree]:                                   90.000
+ CELL_REF| Numerically orthorhombic:                                         YES
+
+ *******************************************************************************
+ *******************************************************************************
+ **                                                                           **
+ **     #####                         ##              ##                      **
+ **    ##   ##            ##          ##              ##                      **
+ **   ##     ##                       ##            ######                    **
+ **   ##     ##  ##   ##  ##   #####  ##  ##   ####   ##    #####    #####    **
+ **   ##     ##  ##   ##  ##  ##      ## ##   ##      ##   ##   ##  ##   ##   **
+ **   ##  ## ##  ##   ##  ##  ##      ####     ###    ##   ######   ######    **
+ **    ##  ###   ##   ##  ##  ##      ## ##      ##   ##   ##       ##        **
+ **     #######   #####   ##   #####  ##  ##  ####    ##    #####   ##        **
+ **           ##                                                    ##        **
+ **                                                                           **
+ **                                                ... make the atoms dance   **
+ **                                                                           **
+ **            Copyright (C) by CP2K Developers Group (2000 - 2014)           **
+ **                                                                           **
+ *******************************************************************************
+
+ DFT| Spin restricted Kohn-Sham (RKS) calculation                            RKS
+ DFT| Multiplicity                                                             1
+ DFT| Number of spin states                                                    1
+ DFT| Charge                                                                   0
+ DFT| Self-interaction correction (SIC)                                       NO
+ DFT| Cutoffs: density                                              1.000000E-10
+ DFT|          gradient                                             1.000000E-10
+ DFT|          tau                                                  1.000000E-10
+ DFT|          cutoff_smoothing_range                               0.000000E+00
+ DFT| XC density smoothing                                                  NONE
+ DFT| XC derivatives                                                          PW
+ FUNCTIONAL| ROUTINE=NEW
+ FUNCTIONAL| PADE:
+ FUNCTIONAL| S. Goedecker, M. Teter and J. Hutter, Phys. Rev. B 54, 1703 (1996)
+
+ QS| Method:                                                                 GPW
+ QS| Density plane wave grid type                        NON-SPHERICAL FULLSPACE
+ QS| Number of grid levels:                                                    4
+ QS| Density cutoff [a.u.]:                                                150.0
+ QS| Multi grid cutoff [a.u.]: 1) grid level                               150.0
+ QS|                           2) grid level                                50.0
+ QS|                           3) grid level                                16.7
+ QS|                           4) grid level                                 5.6
+ QS| Grid level progression factor:                                          3.0
+ QS| Relative density cutoff [a.u.]:                                        30.0
+ QS| Consistent realspace mapping and integration
+ QS| Interaction thresholds: eps_pgf_orb:                                1.0E-05
+ QS|                         eps_filter_matrix:                          0.0E+00
+ QS|                         eps_core_charge:                            1.0E-12
+ QS|                         eps_rho_gspace:                             1.0E-10
+ QS|                         eps_rho_rspace:                             1.0E-10
+ QS|                         eps_gvg_rspace:                             1.0E-05
+ QS|                         eps_ppl:                                    1.0E-02
+ QS|                         eps_ppnl:                                   1.0E-07
+
+
+ ATOMIC KIND INFORMATION
+
+  1. Atomic kind: Si                                    Number of atoms:       8
+
+     Orbital Basis Set                                             DZVP-GTH-PADE
+
+       Number of orbital shell sets:                                           2
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    3s                1.203242       0.269412
+                                                         0.468841      -0.102290
+                                                         0.167986      -0.147195
+                                                         0.057562      -0.015996
+
+                          1       2    4s                1.203242       0.000000
+                                                         0.468841       0.000000
+                                                         0.167986       0.000000
+                                                         0.057562       0.083755
+
+                          1       3    4px               1.203242       0.085242
+                                                         0.468841      -0.143473
+                                                         0.167986      -0.083408
+                                                         0.057562      -0.014565
+                          1       3    4py               1.203242       0.085242
+                                                         0.468841      -0.143473
+                                                         0.167986      -0.083408
+                                                         0.057562      -0.014565
+                          1       3    4pz               1.203242       0.085242
+                                                         0.468841      -0.143473
+                                                         0.167986      -0.083408
+                                                         0.057562      -0.014565
+
+                          1       4    5px               1.203242       0.000000
+                                                         0.468841       0.000000
+                                                         0.167986       0.000000
+                                                         0.057562       0.040189
+                          1       4    5py               1.203242       0.000000
+                                                         0.468841       0.000000
+                                                         0.167986       0.000000
+                                                         0.057562       0.040189
+                          1       4    5pz               1.203242       0.000000
+                                                         0.468841       0.000000
+                                                         0.167986       0.000000
+                                                         0.057562       0.040189
+
+                          2       1    3dx2              0.450000       0.406941
+                          2       1    3dxy              0.450000       0.704842
+                          2       1    3dxz              0.450000       0.704842
+                          2       1    3dy2              0.450000       0.406941
+                          2       1    3dyz              0.450000       0.704842
+                          2       1    3dz2              0.450000       0.406941
+
+     Potential information for                                       GTH-PADE-q4
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               2.582645
+       Electronic configuration (s p d ...):                               2   2
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.440000   -7.336103
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.422738    5.906928   -1.261894
+                                   -1.261894    3.258196
+                   1    0.484278    2.727013
+
+
+ MOLECULE KIND INFORMATION
+
+
+ All atoms are their own molecule, skipping detailed information
+
+
+ TOTAL NUMBERS AND MAXIMUM NUMBERS
+
+  Total number of            - Atomic kinds:                                   1
+                             - Atoms:                                          8
+                             - Shell sets:                                    16
+                             - Shells:                                        40
+                             - Primitive Cartesian functions:                 40
+                             - Cartesian basis functions:                    112
+                             - Spherical basis functions:                    104
+
+  Maximum angular momentum of- Orbital basis functions:                        2
+                             - Local part of the GTH pseudopotential:          0
+                             - Non-local part of the GTH pseudopotential:      2
+
+
+ MODULE QUICKSTEP:  ATOMIC COORDINATES IN angstrom
+
+  Atom  Kind  Element       X           Y           Z          Z(eff)       Mass
+
+       1     1 Si  14    0.000000    0.000000    0.000000      4.00      28.0855
+       2     1 Si  14    0.000000    2.715349    2.715349      4.00      28.0855
+       3     1 Si  14    2.715349    2.715349    0.000000      4.00      28.0855
+       4     1 Si  14    2.715349    0.000000    2.715349      4.00      28.0855
+       5     1 Si  14    4.073023    1.357674    4.073023      4.00      28.0855
+       6     1 Si  14    1.357674    1.357674    1.357674      4.00      28.0855
+       7     1 Si  14    1.357674    4.073023    4.073023      4.00      28.0855
+       8     1 Si  14    4.073023    4.073023    1.357674      4.00      28.0855
+
+
+
+
+ SCF PARAMETERS         Density guess:                                    ATOMIC
+                        --------------------------------------------------------
+                        max_scf:                                             300
+                        max_scf_history:                                       0
+                        max_diis:                                              4
+                        --------------------------------------------------------
+                        eps_scf:                                        1.00E-07
+                        eps_scf_history:                                0.00E+00
+                        eps_diis:                                       1.00E-01
+                        eps_eigval:                                     1.00E-05
+                        --------------------------------------------------------
+                        level_shift [a.u.]:                                 0.00
+                        --------------------------------------------------------
+                        Mixing method:                            BROYDEN_MIXING
+                                                charge density mixing in g-space
+                        --------------------------------------------------------
+                        No outer SCF
+
+ PW_GRID| Information for grid number                                          1
+ PW_GRID| Cutoff [a.u.]                                                    150.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -30      29                Points:          60
+ PW_GRID|   Bounds   2            -30      29                Points:          60
+ PW_GRID|   Bounds   3            -30      29                Points:          60
+ PW_GRID| Volume element (a.u.^3)  0.5004E-02     Volume (a.u.^3)      1080.8451
+ PW_GRID| Grid span                                                    FULLSPACE
+
+ PW_GRID| Information for grid number                                          2
+ PW_GRID| Cutoff [a.u.]                                                     50.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -18      17                Points:          36
+ PW_GRID|   Bounds   2            -18      17                Points:          36
+ PW_GRID|   Bounds   3            -18      17                Points:          36
+ PW_GRID| Volume element (a.u.^3)  0.2317E-01     Volume (a.u.^3)      1080.8451
+ PW_GRID| Grid span                                                    FULLSPACE
+
+ PW_GRID| Information for grid number                                          3
+ PW_GRID| Cutoff [a.u.]                                                     16.7
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -10       9                Points:          20
+ PW_GRID|   Bounds   2            -10       9                Points:          20
+ PW_GRID|   Bounds   3            -10       9                Points:          20
+ PW_GRID| Volume element (a.u.^3)  0.1351         Volume (a.u.^3)      1080.8451
+ PW_GRID| Grid span                                                    FULLSPACE
+
+ PW_GRID| Information for grid number                                          4
+ PW_GRID| Cutoff [a.u.]                                                      5.6
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1             -6       5                Points:          12
+ PW_GRID|   Bounds   2             -6       5                Points:          12
+ PW_GRID|   Bounds   3             -6       5                Points:          12
+ PW_GRID| Volume element (a.u.^3)  0.6255         Volume (a.u.^3)      1080.8451
+ PW_GRID| Grid span                                                    FULLSPACE
+
+ POISSON| Solver                                                        PERIODIC
+ POISSON| Periodicity                                                        XYZ
+
+ RS_GRID| Information for grid number                                          1
+ RS_GRID|   Bounds   1            -30      29                Points:          60
+ RS_GRID|   Bounds   2            -30      29                Points:          60
+ RS_GRID|   Bounds   3            -30      29                Points:          60
+
+ RS_GRID| Information for grid number                                          2
+ RS_GRID|   Bounds   1            -18      17                Points:          36
+ RS_GRID|   Bounds   2            -18      17                Points:          36
+ RS_GRID|   Bounds   3            -18      17                Points:          36
+
+ RS_GRID| Information for grid number                                          3
+ RS_GRID|   Bounds   1            -10       9                Points:          20
+ RS_GRID|   Bounds   2            -10       9                Points:          20
+ RS_GRID|   Bounds   3            -10       9                Points:          20
+
+ RS_GRID| Information for grid number                                          4
+ RS_GRID|   Bounds   1             -6       5                Points:          12
+ RS_GRID|   Bounds   2             -6       5                Points:          12
+ RS_GRID|   Bounds   3             -6       5                Points:          12
+
+ DISTRIBUTION OF THE PARTICLES (ROWS)
+              Process row      Number of particles         Number of matrix rows
+                        0                        8                            -1
+                      Sum                        8                            -1
+
+ DISTRIBUTION OF THE PARTICLES (COLUMNS)
+              Process col      Number of particles      Number of matrix columns
+                        0                        8                            -1
+                      Sum                        8                            -1
+
+ DISTRIBUTION OF THE NEIGHBOR LISTS
+              Total number of particle pairs:                               2952
+              Total number of matrix elements:                            498888
+              Average number of particle pairs:                             2952
+              Maximum number of particle pairs:                             2952
+              Average number of matrix element:                           498888
+              Maximum number of matrix elements:                          498888
+
+
+ DISTRIBUTION OF THE OVERLAP MATRIX
+              Number  of non-zero blocks:                                     36
+              Percentage non-zero blocks:                                 100.00
+              Average number of blocks per CPU:                               36
+              Maximum number of blocks per CPU:                               36
+              Average number of matrix elements per CPU:                    6094
+              Maximum number of matrix elements per CPU:                    6094
+
+ Number of electrons:                                                         32
+ Number of occupied orbitals:                                                 16
+ Number of molecular orbitals:                                                16
+
+ Number of orbital functions:                                                104
+ Number of independent orbital functions:                                    104
+
+ Extrapolation method: initial_guess
+
+ Atomic guess: The first density matrix is obtained in terms of atomic orbitals
+               and electronic configurations assigned to each atomic kind
+
+ Guess for atomic kind: Si
+
+ Electronic structure
+    Total number of core electrons                                         10.00
+    Total number of valence electrons                                       4.00
+    Total number of electrons                                              14.00
+    Multiplicity                                                   not specified
+    S   [  2.00  2.00] 2.00
+    P   [  6.00] 2.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1        0.191310                      -3.618313869735
+                          2        0.731569E-01                  -3.691159009622
+                          3        0.405574E-02                  -3.699900512584
+                          4        0.328704E-02                  -3.699908407293
+                          5        0.320845E-02                  -3.699909118998
+                          6        0.316809E-02                  -3.699909477757
+                          7        0.331859E-05                  -3.699923449535
+                          8        0.110258E-06                  -3.699923449550
+
+ Energy components [Hartree]           Total Energy ::           -3.699923449550
+                                        Band Energy ::           -1.012729790251
+                                     Kinetic Energy ::            1.397012768229
+                                   Potential Energy ::           -5.096936217779
+                                      Virial (-V/T) ::            3.648453567279
+                                        Core Energy ::           -5.703543362687
+                                          XC Energy ::           -0.980691562795
+                                     Coulomb Energy ::            2.984311475932
+                       Total Pseudopotential Energy ::           -7.145739758818
+                       Local Pseudopotential Energy ::           -7.987908627736
+                    Nonlocal Pseudopotential Energy ::            0.842168868918
+                                        Confinement ::            0.451836279031
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.378230          -10.292155
+
+                       1     1          2.000      -0.128135           -3.486734
+
+ Re-scaling the density matrix to get the right number of electrons
+                  # Electrons              Trace(P)               Scaling factor
+                           32                31.129                        1.028
+
+
+ SCF WAVEFUNCTION OPTIMIZATION
+
+  Step     Update method      Time    Convergence         Total energy    Change
+  ------------------------------------------------------------------------------
+
+  Trace(PS):                                   32.0000000000
+  Electronic density on regular grids:        -31.9999999982        0.0000000018
+  Core density on regular grids:               31.9999999939       -0.0000000061
+  Total charge density on r-space grids:       -0.0000000043
+  Total charge density g-space grids:          -0.0000000043
+
+     1 NoMix/Diag. 0.40E+00    0.9     0.75558724       -32.2320848878 -3.22E+01
+
+  Trace(PS):                                   32.0000000000
+  Electronic density on regular grids:        -31.9999999956        0.0000000044
+  Core density on regular grids:               31.9999999939       -0.0000000061
+  Total charge density on r-space grids:       -0.0000000017
+  Total charge density g-space grids:          -0.0000000017
+
+     2 Broy./Diag. 0.40E+00    1.4     0.05667976       -31.1418135481  1.09E+00
+
+  Trace(PS):                                   32.0000000000
+  Electronic density on regular grids:        -31.9999999907        0.0000000093
+  Core density on regular grids:               31.9999999939       -0.0000000061
+  Total charge density on r-space grids:        0.0000000033
+  Total charge density g-space grids:           0.0000000033
+
+     3 Broy./Diag. 0.40E+00    1.4     0.09691469       -31.1974003416 -5.56E-02
+
+  Trace(PS):                                   32.0000000000
+  Electronic density on regular grids:        -31.9999999897        0.0000000103
+  Core density on regular grids:               31.9999999939       -0.0000000061
+  Total charge density on r-space grids:        0.0000000042
+  Total charge density g-space grids:           0.0000000042
+
+     4 Broy./Diag. 0.40E+00    1.4     0.00245608       -31.3378474040 -1.40E-01
+
+  Trace(PS):                                   32.0000000000
+  Electronic density on regular grids:        -31.9999999888        0.0000000112
+  Core density on regular grids:               31.9999999939       -0.0000000061
+  Total charge density on r-space grids:        0.0000000051
+  Total charge density g-space grids:           0.0000000051
+
+     5 Broy./Diag. 0.40E+00    1.4     0.00235460       -31.3009654398  3.69E-02
+
+  Trace(PS):                                   32.0000000000
+  Electronic density on regular grids:        -31.9999999888        0.0000000112
+  Core density on regular grids:               31.9999999939       -0.0000000061
+  Total charge density on r-space grids:        0.0000000051
+  Total charge density g-space grids:           0.0000000051
+
+     6 Broy./Diag. 0.40E+00    1.4     0.00007565       -31.2972158934  3.75E-03
+
+  Trace(PS):                                   32.0000000000
+  Electronic density on regular grids:        -31.9999999889        0.0000000111
+  Core density on regular grids:               31.9999999939       -0.0000000061
+  Total charge density on r-space grids:        0.0000000050
+  Total charge density g-space grids:           0.0000000050
+
+     7 Broy./Diag. 0.40E+00    1.4     0.00009004       -31.2977293749 -5.13E-04
+
+  Trace(PS):                                   32.0000000000
+  Electronic density on regular grids:        -31.9999999889        0.0000000111
+  Core density on regular grids:               31.9999999939       -0.0000000061
+  Total charge density on r-space grids:        0.0000000051
+  Total charge density g-space grids:           0.0000000051
+
+     8 Broy./Diag. 0.40E+00    1.4     0.00000186       -31.2978454163 -1.16E-04
+
+  Trace(PS):                                   32.0000000000
+  Electronic density on regular grids:        -31.9999999889        0.0000000111
+  Core density on regular grids:               31.9999999939       -0.0000000061
+  Total charge density on r-space grids:        0.0000000051
+  Total charge density g-space grids:           0.0000000051
+
+     9 Broy./Diag. 0.40E+00    1.4     0.00000252       -31.2978835492 -3.81E-05
+
+  Trace(PS):                                   32.0000000000
+  Electronic density on regular grids:        -31.9999999889        0.0000000111
+  Core density on regular grids:               31.9999999939       -0.0000000061
+  Total charge density on r-space grids:        0.0000000051
+  Total charge density g-space grids:           0.0000000051
+
+    10 Broy./Diag. 0.40E+00    1.4     5.6405E-09       -31.2978852054 -1.66E-06
+
+  *** SCF run converged in    10 steps ***
+
+
+  Electronic density on regular grids:        -31.9999999889        0.0000000111
+  Core density on regular grids:               31.9999999939       -0.0000000061
+  Total charge density on r-space grids:        0.0000000051
+  Total charge density g-space grids:           0.0000000051
+
+  Overlap energy of the core charge distribution:               0.00000000005320
+  Self energy of the core charge distribution:                -82.06393942512820
+  Core Hamiltonian energy:                                     18.06858429706012
+  Hartree energy:                                              42.41172824581675
+  Exchange-correlation energy:                                 -9.71425832315954
+
+  Total energy:                                               -31.29788520535767

--- a/tests/test_cp2kparser.py
+++ b/tests/test_cp2kparser.py
@@ -61,9 +61,10 @@ def test_single_point(parser):
 
     sec_run = archive.run[0]
     assert sec_run.program.version == 'CP2K version 2.6.2'
+    assert sec_run.x_cp2k_section_startinformation[0].x_cp2k_start_id == 8212
+    assert sec_run.x_cp2k_section_end_information[0].x_cp2k_end_id == 8212
     assert sec_run.x_cp2k_global_settings.get('run_type') == 'ENERGY_FORCE'
 
-    assert sec_run.x_cp2k_section_startinformation[0].x_cp2k_start_id == 8212
     assert (
         sec_run.x_cp2k_section_end_information[0].x_cp2k_end_time
         == '2016-02-08 22:11:17.875'
@@ -130,6 +131,13 @@ def test_single_point(parser):
     assert False not in sec_system.atoms.periodic
 
     assert archive.workflow2.m_def.name == 'SinglePoint'
+
+
+def test_unterminated_section(parser):
+    """Test the proper extraction of process ID"""
+    archive = EntryArchive()
+    parser.parse('tests/data/cp2k/single_point/si_bulk8_unterminated.out', archive, None)
+    assert archive.run[0].x_cp2k_section_startinformation[0].x_cp2k_start_id == 8212
 
 
 def test_pdos(parser):

--- a/tests/test_cp2kparser.py
+++ b/tests/test_cp2kparser.py
@@ -88,8 +88,8 @@ def test_single_point(parser):
 
     sec_method = sec_run.method[0]
     sec_basis_sets = sec_method.electrons_representation[0].basis_set
-    assert sec_basis_sets[0].cutoff.magnitude == approx(6.53961708e-16)
-    assert sec_basis_sets[1].atom_centered[0].name == 'DZVP-GTH-PADE'
+    assert sec_basis_sets[0].atom_centered[0].name == 'DZVP-GTH-PADE'
+    assert sec_basis_sets[1].cutoff.magnitude == approx(6.53961708e-16)
     assert sec_method.scf.threshold_energy_change.magnitude == approx(
         4.35974472220717e-25
     )


### PR DESCRIPTION
- Add support for missing "PROCESS ID" at the end.
- Fix void assignment of plane-wave cutoff.

Closes #242 