### PR TITLE
Fix broken tests (Psi4, Ocean)

### DIFF
--- a/tests/test_oceanparser.py
+++ b/tests/test_oceanparser.py
@@ -18,7 +18,6 @@
 
 import pytest
 import numpy as np
-import re
 
 from nomad.datamodel import EntryArchive
 from electronicparsers.ocean import OceanParser
@@ -65,9 +64,8 @@ def test_tio2(parser):
     assert sec_bse.core_hole.broadening.to('eV').magnitude == approx(0.89)
 
     sec_ocean_screen = sec_method[-1].x_ocean_screen
-    for screen_param in vars(x_ocean_screen_parameters).keys():
-        if re.match('x_ocean_', screen_param):
-            assert getattr(sec_ocean_screen, screen_param) is not None
+    for screen_param in x_ocean_screen_parameters.m_def.quantities:
+        assert sec_ocean_screen.m_is_set(screen_param)
     assert sec_ocean_screen.x_ocean_dft_energy_range == approx(150.0)
 
     # Calculation

--- a/tests/test_oceanparser.py
+++ b/tests/test_oceanparser.py
@@ -18,9 +18,11 @@
 
 import pytest
 import numpy as np
+import re
 
 from nomad.datamodel import EntryArchive
 from electronicparsers.ocean import OceanParser
+from electronicparsers.ocean.metainfo.ocean import x_ocean_screen_parameters
 
 
 def approx(value, abs=0, rel=1e-6):
@@ -61,8 +63,11 @@ def test_tio2(parser):
     assert sec_bse.core_hole.solver == 'Lanczos-Haydock'
     assert sec_bse.core_hole.mode == 'absorption'
     assert sec_bse.core_hole.broadening.to('eV').magnitude == approx(0.89)
+
     sec_ocean_screen = sec_method[-1].x_ocean_screen
-    assert sec_ocean_screen.m_mod_count == 22
+    for screen_param in vars(x_ocean_screen_parameters).keys():
+        if re.match('x_ocean_', screen_param):
+            assert getattr(sec_ocean_screen, screen_param) is not None
     assert sec_ocean_screen.x_ocean_dft_energy_range == approx(150.0)
 
     # Calculation

--- a/tests/test_psi4parser.py
+++ b/tests/test_psi4parser.py
@@ -135,11 +135,16 @@ def test_ecp_basis(parser):
     assert method[5].electronic.method == 'RHF'
 
     calc = archive.run[0].calculation
-    assert len(calc) == 5
+    assert len(calc) in (5, 6)
     assert calc[3].energy.total.value.magnitude == approx(-1.29372859e-15)
     assert calc[4].scf_iteration[1].energy.total.value.magnitude == approx(
         -3.00651252e-14
     )
+    if len(calc) == 6:  # cover failed calculation step
+        assert calc[-1].calculations_ref is None
+        assert calc[-1].method_ref == archive.run[0].method[5]
+        assert calc[-1].system_ref == archive.run[0].system[5]
+        # TODO: add check for basis set to really identify the failed step
 
 
 def test_dft(parser):


### PR DESCRIPTION
Modify the tests as discussed in #260 :

- Psi4: capture failed calculation.
- Ocean: improve metric for full-coverage of `x_ocean_screen_parameters`