### PR TITLE
Patch QE `n_electrons`

### DIFF
--- a/electronicparsers/quantumespresso/parser.py
+++ b/electronicparsers/quantumespresso/parser.py
@@ -2037,7 +2037,12 @@ class QuantumEspressoOutParser(TextParser):
             ),
             Quantity(
                 'number_of_electrons',
-                rf'number of electrons\s*=\s*({re_float})\s*(?:\(up:\s*({re_float})\s*,\s*down:\s*({re_float}))?',
+                rf'number of electrons\s*=\s*({re_float})',
+                dtype=float,
+            ),
+            Quantity(
+                'number_of_spin_electrons',
+                rf'number of electrons\s*=[\s\S]*up:\s*({re_float})\s*,\s*down:\s*({re_float})',
                 dtype=float,
             ),
             Quantity(
@@ -3489,16 +3494,10 @@ class QuantumEspressoParser:
                 if atom_sp[i] is not None:
                     setattr(sec_method_atom_kind, atom_species_names[i], atom_sp[i])
 
-        n_electrons = run.get_header('number_of_electrons', [])
-        if len(n_electrons) == 3:
-            sec_method.electronic.n_electrons = n_electrons[0]
-        elif len(n_electrons) == 0:
-            pass
-        else:
-            self.logger.warning(
-                'Corrupted extraction `n_electrons`. Cannot set value.',
-                n_electrons=n_electrons,
-            )  # this error could be better managed if we retianed the og keys
+        if (n_electrons := run.get_header('number_of_electrons')) is not None:
+            sec_method.electronic.n_electrons = n_electrons
+        elif len(n_spin_electrons := list(run.get_header('number_of_spin_electrons', []))) == 2:
+            sec_method.electronic.n_electrons = sum(n_spin_electrons)
 
     def init_parser(self):
         self.out_parser.mainfile = self.filepath

--- a/electronicparsers/quantumespresso/parser.py
+++ b/electronicparsers/quantumespresso/parser.py
@@ -2909,8 +2909,8 @@ class QuantumEspressoParser:
             if np.array(fermi_energy).dtype == float:
                 sec_energy.fermi = fermi_energy * ureg.eV
 
-        n_electrons = run.get_header('number_of_electrons')
-        if homo is None and fermi_energy is None and n_electrons is None:
+        n_electrons = run.get_header('number_of_electrons', [])
+        if homo is None and fermi_energy is None and len(n_electrons)==0:
             self.logger.error('Reference energy is not defined')
 
         for key in ['magnetization_total', 'magnetization_absolute']:
@@ -3489,14 +3489,19 @@ class QuantumEspressoParser:
                 if atom_sp[i] is not None:
                     setattr(sec_method_atom_kind, atom_species_names[i], atom_sp[i])
 
-        number_of_electrons = run.get_header('number_of_electrons')
-        if number_of_electrons is not None:
-            number_of_electrons = (
-                [number_of_electrons]
-                if isinstance(number_of_electrons, float)
-                else number_of_electrons
-            )
-            sec_method.electronic.n_electrons = number_of_electrons
+        number_of_electrons = run.get_header('number_of_electrons', [])
+        if len(number_of_electrons) == 3:
+            sec_method.electronic.n_electrons = number_of_electrons[0]
+        elif len(number_of_electrons) == 2:
+            self.logger.warning('Number of electrons is not defined. Cannot set `n_electrons`.')
+        elif len(number_of_electrons) == 1:
+            self.logger.warning('Number of electrons is not defined')
+            sec_method.electronic.n_electrons = number_of_electrons[0]
+        elif len(number_of_electrons) == 0:
+            pass
+        else:
+            self.logger.error('Number of electrons format is corrputed', number_of_electrons)
+
 
     def init_parser(self):
         self.out_parser.mainfile = self.filepath

--- a/electronicparsers/quantumespresso/parser.py
+++ b/electronicparsers/quantumespresso/parser.py
@@ -3489,18 +3489,18 @@ class QuantumEspressoParser:
                 if atom_sp[i] is not None:
                     setattr(sec_method_atom_kind, atom_species_names[i], atom_sp[i])
 
-        number_of_electrons = run.get_header('number_of_electrons', [])
-        if len(number_of_electrons) == 3:
-            sec_method.electronic.n_electrons = number_of_electrons[0]
-        elif len(number_of_electrons) == 2:
-            self.logger.warning('Number of electrons is not defined. Cannot set `n_electrons`.')
-        elif len(number_of_electrons) == 1:
-            self.logger.warning('Number of electrons is not defined')
-            sec_method.electronic.n_electrons = number_of_electrons[0]
-        elif len(number_of_electrons) == 0:
+        n_electrons = run.get_header('number_of_electrons', [])
+        if len(n_electrons) == 3:
+            sec_method.electronic.n_electrons = n_electrons[0]
+        elif len(n_electrons) == 2:
+            self.logger.warning('Corrupted extraction `n_electrons`. Cannot set value.')
+        elif len(n_electrons) == 1:
+            self.logger.warning('Corrupted extraction `n_electrons`. Will set a tentative value.')  # ? Maybe it shouldn't set anything
+            sec_method.electronic.n_electrons = n_electrons[0]
+        elif len(n_electrons) == 0:
             pass
         else:
-            self.logger.error('Number of electrons format is corrputed', number_of_electrons)
+            self.logger.warning('Corrupted extraction `n_electrons`. Cannot set value.', n_electrons=n_electrons)
 
 
     def init_parser(self):

--- a/electronicparsers/quantumespresso/parser.py
+++ b/electronicparsers/quantumespresso/parser.py
@@ -3496,7 +3496,12 @@ class QuantumEspressoParser:
 
         if (n_electrons := run.get_header('number_of_electrons')) is not None:
             sec_method.electronic.n_electrons = n_electrons
-        elif len(n_spin_electrons := list(run.get_header('number_of_spin_electrons', []))) == 2:
+        elif (
+            len(
+                n_spin_electrons := list(run.get_header('number_of_spin_electrons', []))
+            )
+            == 2
+        ):
             sec_method.electronic.n_electrons = sum(n_spin_electrons)
 
     def init_parser(self):

--- a/electronicparsers/quantumespresso/parser.py
+++ b/electronicparsers/quantumespresso/parser.py
@@ -2037,13 +2037,14 @@ class QuantumEspressoOutParser(TextParser):
             ),
             Quantity(
                 'number_of_electrons',
-                rf'number of electrons\s*=\s*({re_float})',
-                dtype=float,
-            ),
-            Quantity(
-                'number_of_spin_electrons',
-                rf'number of electrons\s*=[\s\S]*up:\s*({re_float})\s*,\s*down:\s*({re_float})',
-                dtype=float,
+                rf'(number of electrons\s*=[^\n]*)',
+                sub_parser=TextParser(
+                    quantities=[
+                        Quantity('total', rf'number of electrons\s*=\s*({re_float})', dtype=float),
+                        Quantity('up', rf'up:\s*({re_float})', dtype=float),
+                        Quantity('down', rf'down:\s*({re_float})', dtype=float),
+                    ],
+                ),
             ),
             Quantity(
                 'x_qe_number_of_states',
@@ -2795,6 +2796,16 @@ class QuantumEspressoParser:
         }
         self._re_label = re.compile(r'([A-Z][a-z]?)')
 
+    def get_n_electrons_safe(self) -> float:
+        n_electrons = self.out_parser.get('run', [])
+        if n_electrons:
+            n_electrons = n_electrons[0].get_header('number_of_electrons', {})
+            if total_n_electrons := n_electrons.get('total'):
+                return total_n_electrons
+            elif (up := n_electrons.get('up')) and (down := n_electrons.get('down')):
+                self.logger.warning('Number of electrons not found. Using spin up + down.')
+                return up + down
+
     def parse_scc(self, run, calculation):
         sec_run = self.archive.run[-1]
         initial_time = (
@@ -2914,8 +2925,7 @@ class QuantumEspressoParser:
             if np.array(fermi_energy).dtype == float:
                 sec_energy.fermi = fermi_energy * ureg.eV
 
-        n_electrons = run.get_header('number_of_electrons', [])
-        if homo is None and fermi_energy is None and len(n_electrons) == 0:
+        if homo is None and fermi_energy is None and len(self.get_n_electrons_safe()) == 0:
             self.logger.error('Reference energy is not defined')
 
         for key in ['magnetization_total', 'magnetization_absolute']:
@@ -3494,15 +3504,7 @@ class QuantumEspressoParser:
                 if atom_sp[i] is not None:
                     setattr(sec_method_atom_kind, atom_species_names[i], atom_sp[i])
 
-        if (n_electrons := run.get_header('number_of_electrons')) is not None:
-            sec_method.electronic.n_electrons = n_electrons
-        elif (
-            len(
-                n_spin_electrons := list(run.get_header('number_of_spin_electrons', []))
-            )
-            == 2
-        ):
-            sec_method.electronic.n_electrons = sum(n_spin_electrons)
+        sec_method.electronic.n_electrons = self.get_n_electrons_safe()
 
     def init_parser(self):
         self.out_parser.mainfile = self.filepath

--- a/electronicparsers/quantumespresso/parser.py
+++ b/electronicparsers/quantumespresso/parser.py
@@ -2040,7 +2040,11 @@ class QuantumEspressoOutParser(TextParser):
                 rf'(number of electrons\s*=[^\n]*)',
                 sub_parser=TextParser(
                     quantities=[
-                        Quantity('total', rf'number of electrons\s*=\s*({re_float})', dtype=float),
+                        Quantity(
+                            'total',
+                            rf'number of electrons\s*=\s*({re_float})',
+                            dtype=float,
+                        ),
                         Quantity('up', rf'up:\s*({re_float})', dtype=float),
                         Quantity('down', rf'down:\s*({re_float})', dtype=float),
                     ],
@@ -2803,7 +2807,9 @@ class QuantumEspressoParser:
             if total_n_electrons := n_electrons.get('total'):
                 return total_n_electrons
             elif (up := n_electrons.get('up')) and (down := n_electrons.get('down')):
-                self.logger.warning('Number of electrons not found. Using spin up + down.')
+                self.logger.warning(
+                    'Number of electrons not found. Using spin up + down.'
+                )
                 return up + down
 
     def parse_scc(self, run, calculation):
@@ -2925,7 +2931,11 @@ class QuantumEspressoParser:
             if np.array(fermi_energy).dtype == float:
                 sec_energy.fermi = fermi_energy * ureg.eV
 
-        if homo is None and fermi_energy is None and len(self.get_n_electrons_safe()) == 0:
+        if (
+            homo is None
+            and fermi_energy is None
+            and len(self.get_n_electrons_safe()) == 0
+        ):
             self.logger.error('Reference energy is not defined')
 
         for key in ['magnetization_total', 'magnetization_absolute']:

--- a/electronicparsers/quantumespresso/parser.py
+++ b/electronicparsers/quantumespresso/parser.py
@@ -2910,7 +2910,7 @@ class QuantumEspressoParser:
                 sec_energy.fermi = fermi_energy * ureg.eV
 
         n_electrons = run.get_header('number_of_electrons', [])
-        if homo is None and fermi_energy is None and len(n_electrons)==0:
+        if homo is None and fermi_energy is None and len(n_electrons) == 0:
             self.logger.error('Reference energy is not defined')
 
         for key in ['magnetization_total', 'magnetization_absolute']:
@@ -3495,13 +3495,17 @@ class QuantumEspressoParser:
         elif len(n_electrons) == 2:
             self.logger.warning('Corrupted extraction `n_electrons`. Cannot set value.')
         elif len(n_electrons) == 1:
-            self.logger.warning('Corrupted extraction `n_electrons`. Will set a tentative value.')  # ? Maybe it shouldn't set anything
+            self.logger.warning(
+                'Corrupted extraction `n_electrons`. Will set a tentative value.'
+            )  # ? Maybe it shouldn't set anything
             sec_method.electronic.n_electrons = n_electrons[0]
         elif len(n_electrons) == 0:
             pass
         else:
-            self.logger.warning('Corrupted extraction `n_electrons`. Cannot set value.', n_electrons=n_electrons)
-
+            self.logger.warning(
+                'Corrupted extraction `n_electrons`. Cannot set value.',
+                n_electrons=n_electrons,
+            )
 
     def init_parser(self):
         self.out_parser.mainfile = self.filepath

--- a/electronicparsers/quantumespresso/parser.py
+++ b/electronicparsers/quantumespresso/parser.py
@@ -3492,20 +3492,13 @@ class QuantumEspressoParser:
         n_electrons = run.get_header('number_of_electrons', [])
         if len(n_electrons) == 3:
             sec_method.electronic.n_electrons = n_electrons[0]
-        elif len(n_electrons) == 2:
-            self.logger.warning('Corrupted extraction `n_electrons`. Cannot set value.')
-        elif len(n_electrons) == 1:
-            self.logger.warning(
-                'Corrupted extraction `n_electrons`. Will set a tentative value.'
-            )  # ? Maybe it shouldn't set anything
-            sec_method.electronic.n_electrons = n_electrons[0]
         elif len(n_electrons) == 0:
             pass
         else:
             self.logger.warning(
                 'Corrupted extraction `n_electrons`. Cannot set value.',
                 n_electrons=n_electrons,
-            )
+            )  # this error could be better managed if we retianed the og keys
 
     def init_parser(self):
         self.out_parser.mainfile = self.filepath

--- a/electronicparsers/quantumespresso/parser.py
+++ b/electronicparsers/quantumespresso/parser.py
@@ -21,6 +21,7 @@ import numpy as np
 import re
 from datetime import datetime
 import os
+from typing import Optional
 
 from nomad.units import ureg
 from nomad.parsing.file_parser.text_parser import TextParser, Quantity, DataTextParser
@@ -2800,7 +2801,7 @@ class QuantumEspressoParser:
         }
         self._re_label = re.compile(r'([A-Z][a-z]?)')
 
-    def get_n_electrons_safe(self) -> float:
+    def get_n_electrons_safe(self) -> Optional[float]:
         n_electrons = self.out_parser.get('run', [])
         if n_electrons:
             n_electrons = n_electrons[0].get_header('number_of_electrons', {})
@@ -2811,6 +2812,7 @@ class QuantumEspressoParser:
                     'Number of electrons not found. Using spin up + down.'
                 )
                 return up + down
+        return None
 
     def parse_scc(self, run, calculation):
         sec_run = self.archive.run[-1]

--- a/tests/test_quantumespressoparser.py
+++ b/tests/test_quantumespressoparser.py
@@ -71,7 +71,7 @@ def test_scf(parser):
     assert len(sec_method.dft.xc_functional.exchange) == 1
     assert sec_method.x_qe_xc_igcc_name == 'pbc'
     assert sec_method.dft.xc_functional.exchange[0].name == 'GGA_X_PBE'
-    assert sec_method.electronic.n_electrons[0] == 8
+    assert sec_method.electronic.n_electrons == 8
     assert sec_method.electronic.n_spin_channels == 1
     sec_atoms = sec_method.atom_parameters
     assert len(sec_atoms) == 2


### PR DESCRIPTION
A user pointed out that with spin-polarization turned on, the QE parser extracts 3 values for the total electron count and attempts to assign them, causing an error:

```
"exception":string"Traceback (most recent call last): File "/home/cecilia/lavoro/nomad-distro-dev-aa/packages/nomad-FAIR/nomad/processing/data.py", line 1508, in parsing parser.parse( File "/home/cecilia/lavoro/nomad-distro-dev-aa/packages/nomad-FAIR/nomad/parsing/parser.py", line 460, in parse self.mainfile_parser.parse(mainfile, archive, logger) File "/home/cecilia/lavoro/nomad-distro-dev-aa/.venv/lib/python3.12/site-packages/electronicparsers/quantumespresso/parser.py", line 3563, in parse self.parse_method(run) File "/home/cecilia/lavoro/nomad-distro-dev-aa/.venv/lib/python3.12/site-packages/electronicparsers/quantumespresso/parser.py", line 3499, in parse_method sec_method.electronic.n_electrons = number_of_electrons ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/cecilia/lavoro/nomad-distro-dev-aa/packages/nomad-FAIR/nomad/metainfo/metainfo.py", line 1090, in __setattr__ return super().__setattr__(name, value) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/cecilia/lavoro/nomad-distro-dev-aa/packages/nomad-FAIR/nomad/metainfo/metainfo.py", line 727, in wrapper return method(self, obj, value, **kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/cecilia/lavoro/nomad-distro-dev-aa/packages/nomad-FAIR/nomad/metainfo/metainfo.py", line 3273, in __set__ value = self.type.normalize(value, section=obj, **kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/cecilia/lavoro/nomad-distro-dev-aa/packages/nomad-FAIR/nomad/metainfo/data_type.py", line 546, in normalize return super().normalize(value, **kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/cecilia/lavoro/nomad-distro-dev-aa/packages/nomad-FAIR/nomad/metainfo/data_type.py", line 294, in normalize raise ValueError( ValueError: Cannot set [7. 4. 3.] for the scalar quantity runschema.method.Electronic.n_electrons:Quantity."
"timestamp":string"2025-01-16 15:53.12"
"level":string"ERROR"
}
```