### PR TITLE
input validation for atomic species from VASP xml output

### DIFF
--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -2000,6 +2000,8 @@ class VASPParser:
                         atom_index = self.parser.atom_info.get('atomtypes', {}).get('element', []).index(_label)
                         # get the label from the PP info. The second entry appears to be the chemical element.
                         recovered_label = self.parser.atom_info.get('atomtypes', {}).get('pseudopotential')[atom_index][1]
+                        # account for cases where PP names include underscores
+                        recovered_label = recovered_label.split('_')[0]
                         assert recovered_label in self.allowed_species, 'Recovered species label is also invalid'
                         sec_atoms.labels[idx] = recovered_label
                     except Exception as e:

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -1642,6 +1642,7 @@ class VASPParser:
             'GW0R': 'scGW0',
             'GWR': 'scGW',
         }
+        self.allowed_species = set(ase.data.chemical_symbols[1:])
 
     def init_parser(self, filepath, logger):
         self.parser = (
@@ -1990,19 +1991,19 @@ class VASPParser:
             sec_atoms.periodic = [True] * 3
             sec_atoms.labels = self.parser.atom_info.get('atoms', {}).get('element', [])
             # create a set of allowed species for faster lookup. The ase data starts with a vacancy labelled 'X', so start with the second entry.
-            allowed_species = set(ase.data.chemical_symbols[1:])
-            unidentified_labels = [(idx, label) for idx, label in enumerate(sec_atoms.labels) if label not in allowed_species]
+            unidentified_labels = [(idx, label) for idx, label in enumerate(sec_atoms.labels) if label not in self.allowed_species]
             if len(unidentified_labels) > 0:
-                self.logger.warning(f'Unidentified atom labels: {unidentified_labels}')
+                self.logger.warning('Unidentified atom labels.', data=list(zip(*unidentified_labels))[1])
                 for idx, _label in unidentified_labels:
                     try:
                         # get the atom index of wrong species
                         atom_index = self.parser.atom_info.get('atomtypes', {}).get('element', []).index(_label)
-                        # get the label from the PP info
-                        # the second entry appears to be the chemical element; there may be a more sustainable way to get this info
-                        sec_atoms.labels[idx] = self.parser.atom_info.get('atomtypes', {}).get('pseudopotential')[atom_index][1]
-                    except Exception:
-                        self.logger.error(f'Unable to recover atom label {_label}.')
+                        # get the label from the PP info. The second entry appears to be the chemical element.
+                        recovered_label = self.parser.atom_info.get('atomtypes', {}).get('pseudopotential')[atom_index][1]
+                        assert recovered_label in self.allowed_species, 'Recovered species label is also invalid'
+                        sec_atoms.labels[idx] = recovered_label
+                    except Exception as e:
+                        self.logger.error('Unable to recover atom label.', data=_label, reason=str(e))
 
             positions = structure.get('positions', None)
             if positions is not None:

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -1989,6 +1989,20 @@ class VASPParser:
 
             sec_atoms.periodic = [True] * 3
             sec_atoms.labels = self.parser.atom_info.get('atoms', {}).get('element', [])
+            # create a set of allowed species for faster lookup. The ase data starts with a vacancy labelled 'X', so start with the second entry.
+            allowed_species = set(ase.data.chemical_symbols[1:])
+            unidentified_labels = [(idx, label) for idx, label in enumerate(sec_atoms.labels) if label not in allowed_species]
+            if len(unidentified_labels) > 0:
+                self.logger.warning(f'Unidentified atom labels: {unidentified_labels}')
+                for idx, _label in unidentified_labels:
+                    try:
+                        # get the atom index of wrong species
+                        atom_index = self.parser.atom_info.get('atomtypes', {}).get('element', []).index(_label)
+                        # get the label from the PP info
+                        # the second entry appears to be the chemical element; there may be a more sustainable way to get this info
+                        sec_atoms.labels[idx] = self.parser.atom_info.get('atomtypes', {}).get('pseudopotential')[atom_index][1]
+                    except Exception:
+                        self.logger.error(f'Unable to recover atom label {_label}.')
 
             positions = structure.get('positions', None)
             if positions is not None:


### PR DESCRIPTION
This addresses the issue described here: https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/issues/1850  
The VASP code apparently set the name of the chemical species incorrectly, such that in some cases the descriptions of the elements in the structure section are wrong, e.g. here: https://nomad-lab.eu/prod/v1/gui/search/calculations/entry/id/zlkl1vpS3QHliZfRRxU856Q8sTRF .

Previously, these cases were not detected. I added input validation, by checking that all elements in the section system are actual atom names. If that is not true, a log message is written and it tries to recover by reading the element name from the pseudopotential description. If that also fails another log message is written.

@ndaelman-hu , you looked into this before: Would this fix also solve the other cases you have seen?