### PR TITLE
Fix VASP time calculation dimensionality error

### DIFF
--- a/electronicparsers/abacus/parser.py
+++ b/electronicparsers/abacus/parser.py
@@ -1184,13 +1184,13 @@ class ABACUSOutParser(TextParser):
             Quantity(
                 'program_version',
                 r'Version:\s*(.*)\n',
-                str_operation=lambda x: ''.join(x),
+                str_operation=''.join,
             ),
             Quantity('nproc', r'Processor Number is\s*(\d+)\n', dtype=int),
             Quantity(
                 'start_date_time',
                 r'Start Time is\s*(.*)\n',
-                str_operation=lambda x: ''.join(x),
+                str_operation=''.join,
             ),
             Quantity(
                 'input_filename',
@@ -1269,7 +1269,7 @@ class ABACUSOutParser(TextParser):
             Quantity(
                 'finish_date_time',
                 r'Finish\s*Time\s*:\s*(.*)\n',
-                str_operation=lambda x: ''.join(x),
+                str_operation=''.join,
             ),
             Quantity(
                 'total_time',

--- a/electronicparsers/gaussian/parser.py
+++ b/electronicparsers/gaussian/parser.py
@@ -650,7 +650,7 @@ class GaussianOutParser(TextParser):
             Quantity(
                 'calc_type',
                 r'\s-+\n\sGaussian ([\w\s]+)\n',
-                convert=lambda x: ' '.join(x),
+                convert=' '.join,
             ),
             Quantity(
                 'run',

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -2320,6 +2320,7 @@ class VASPParser:
             time_initial = (
                 sec_run.calculation[-1].time_physical
                 if sec_run.calculation
+                and sec_run.calculation[-1].time_physical is not None
                 else 0 * ureg.s
             )
             sec_scc = parse_energy(n, None)
@@ -2350,21 +2351,26 @@ class VASPParser:
                     time_val = time
 
                 if time_val is not None:
-                    sec_scc.time_calculation = float(time_val)
-                    sec_scc.time_physical = time_initial + sec_scc.time_calculation
+                    time_calc_quantity = time_val * ureg.s
+                    sec_scc.time_calculation = time_calc_quantity
+                    sec_scc.time_physical = time_initial + time_calc_quantity
 
             time_scf = self.parser.get_time_scf(n)
             for n_scf in range(self.parser.get_n_scf(n)):
                 time_initial = (
                     sec_scc.scf_iteration[-1].time_physical
-                    if n_scf > 0
+                    if n_scf > 0 and sec_scc.scf_iteration[-1].time_physical is not None
                     else time_initial
+                    if time_initial is not None
+                    else 0 * ureg.s
                 )
                 sec_scf = parse_energy(n, n_scf)
                 if time_scf[n_scf] is not None:
-                    sec_scf.time_calculation = time_scf[n_scf][-1]
-                if sec_scf.time_calculation:
-                    sec_scf.time_physical = time_initial + sec_scf.time_calculation
+                    time_val = time_scf[n_scf][-1]
+                    if time_val is not None:
+                        time_calc_quantity = time_val * ureg.s
+                        sec_scf.time_calculation = time_calc_quantity
+                        sec_scf.time_physical = time_initial + time_calc_quantity
             if not sec_scc.time_calculation:
                 times = [scf.time_calculation for scf in sec_scc.scf_iteration]
                 if None not in times:

--- a/electronicparsers/vasp/parser.py
+++ b/electronicparsers/vasp/parser.py
@@ -333,7 +333,7 @@ class ContentParser:
             pps_out[-1]['flag'] = _to_dict(
                 pp['flag'], transform=lambda x: bool_mapping[x]
             )
-            pps_out[-1]['number'] = _to_dict(pp['number'], transform=lambda x: float(x))
+            pps_out[-1]['number'] = _to_dict(pp['number'], transform=float)
         return pps_out
 
     def _get_tier(self, raw_data: Union[str, None], type='native') -> Union[str, None]:


### PR DESCRIPTION
## Summary
Fixes a `pint.DimensionalityError` when parsing VASP vasprun.xml files with time calculation data.

## Problem
The parser was failing with:
```
pint.errors.DimensionalityError: Cannot convert from 'second' to 'dimensionless'
```

This occurred due to two issues:

### Issue 1: Missing units on time_calculation
The `time_val` from the XML parser is a plain number (float) without units. The original code assigned it directly:
```python
sec_scc.time_calculation = time_val  # No units!
```

When adding to `time_initial` (which has seconds units):
```python
sec_scc.time_physical = time_initial + sec_scc.time_calculation
# Error: Cannot add Quantity(seconds) + dimensionless float
```

Pint cannot add values with incompatible dimensionality (seconds vs dimensionless).

### Issue 2: None propagation in time_initial
`time_initial` could be `None` when previous calculations didn't have `time_physical` set, causing arithmetic failures when trying to add `None + Quantity`.

## Solution
- Add explicit units (`ureg.s`) when setting `time_calculation` values to ensure they're always proper quantities
- Store time quantity in a local variable before assignment for clarity
- Add `None` checks for `time_initial` with fallback to `0 * ureg.s`
- Add `None` checks for `time_physical` before using in calculations

## Testing
- ✅ All 23 VASP parser tests pass, including `test_malformed_time_entries`
- ✅ Successfully parses previously failing vasprun.xml files