### PR TITLE
Fix incorrect units for BSE-calculated spectra

### DIFF
--- a/electronicparsers/exciting/parser.py
+++ b/electronicparsers/exciting/parser.py
@@ -2329,8 +2329,8 @@ class ExcitingParser(BeyondDFTWorkflowsParser):
             sec_scc.spectra.append(sec_spectra)
             sec_spectra.n_energies = n_epsilon
             sec_spectra.excitation_energies = data[0] * ureg.hartree
-            sec_spectra.intensities = data[2]
-            sec_spectra.intensities_units = 'F/m'
+            sec_spectra.intensities = data[2]  # Imaginary part of dielectric function
+            sec_spectra.intensities_units = 'dimensionless'
 
         def parse_sigma(data, sec_scc):
             n_components = len(data)

--- a/electronicparsers/ocean/parser.py
+++ b/electronicparsers/ocean/parser.py
@@ -235,8 +235,8 @@ class OceanParser(BeyondDFTWorkflowsParser):
         sec_spectra.type = self.data['calc'].get('mode').upper()
         sec_spectra.n_energies = len(data_spct)
         sec_spectra.excitation_energies = data_spct[:, 0] * ureg.eV
-        sec_spectra.intensities = data_spct[:, 2]
-        sec_spectra.intensities_units = 'F/m'
+        sec_spectra.intensities = data_spct[:, 2]  # BSE absorption/emission spectra (dielectric function)
+        sec_spectra.intensities_units = 'dimensionless'
 
         # lanczos matrices
         lanc_file = [


### PR DESCRIPTION
## Summary

Both Exciting and OCEAN parsers were incorrectly setting `intensities_units = 'F/m'` for BSE-calculated absorption spectra. These parsers actually calculate the macroscopic dielectric function ε(ω), which is **dimensionless**.

## Background

The confusion arose from conflating two different quantities:
- **Dielectric function/constant** (dimensionless) - what BSE calculates
- **Absolute permittivity** (F/m units) - different quantity

## Changes

### Exciting parser (`electronicparsers/exciting/parser.py:2333`)
```python
sec_spectra.intensities = data[2]  # Imaginary part of dielectric function  
sec_spectra.intensities_units = 'dimensionless'
```

### OCEAN parser (`electronicparsers/ocean/parser.py:239`)
```python
sec_spectra.intensities = data_spct[:, 2]  # BSE absorption/emission spectra (dielectric function)
sec_spectra.intensities_units = 'dimensionless'
```

## Testing

- All Exciting parser tests pass (8 passed, 1 skipped)
- All OCEAN parser tests pass (1 passed)

## References

- Fixes #334
- Related schema discussion: nomad-coe/nomad-schema-plugin-run#24
- OCEAN documentation confirms dielectric function is dimensionless: [PMC9844114](https://pmc.ncbi.nlm.nih.gov/articles/PMC9844114/)